### PR TITLE
Mejora de la lógica de búsqueda de vehículos y soporte para modelos numéricos

### DIFF
--- a/navigation.js
+++ b/navigation.js
@@ -49,8 +49,8 @@ export function filtrarContenido(textoBusqueda) {
         yearSearchTerm = null;
     }
 
-    const nonYearBusqueda = yearSearchTerm ? busqueda.replace(yearSearchMatch[0], '').trim() : busqueda;
-    const palabrasBusqueda = nonYearBusqueda.split(' ').filter(p => p);
+    // Las palabras de búsqueda se derivan de la consulta completa para no excluir números de modelo (ej. 1500)
+    const palabrasBusqueda = busqueda.split(' ').filter(p => p);
 
     datosFiltrados = cortes.filter(item => {
         // 1. Verificación del año (si se especificó uno).
@@ -62,9 +62,13 @@ export function filtrarContenido(textoBusqueda) {
             }
         }
         // 2. Verificación del texto (si hay términos de búsqueda de texto).
-        if (nonYearBusqueda) {
-            const itemTexto = `${item.marca} ${item.modelo} ${item.versionesAplicables}`.toLowerCase();
-            return palabrasBusqueda.every(palabra => itemTexto.includes(palabra));
+        if (busqueda) {
+            const itemTexto = `${String(item.marca)} ${String(item.modelo)} ${String(item.versionesAplicables || '')} ${String(item.tipoEncendido || '')} ${String(item.categoria || '')} ${String(item.anoDesde || '')} ${String(item.anoHasta || '')}`.toLowerCase();
+            return palabrasBusqueda.every(palabra => {
+                // Si la palabra es exactamente el año detectado, ya se verificó con el rango.
+                if (yearSearchTerm && palabra === String(yearSearchTerm)) return true;
+                return itemTexto.includes(palabra);
+            });
         }
         // 3. Si solo se buscó un año y pasó la verificación, se incluye.
         return !!yearSearchTerm;
@@ -81,7 +85,7 @@ export function filtrarContenido(textoBusqueda) {
 
     // Se considera una búsqueda de marca si solo hay una marca en los resultados
     // y el término de búsqueda coincide con el nombre de esa marca.
-    const exactModelMatch = datosFiltrados.some(item => item.modelo.toLowerCase() === busqueda);
+    const exactModelMatch = datosFiltrados.some(item => String(item.modelo).toLowerCase() === busqueda);
 
     if (!exactModelMatch && uniqueMarcasEnResultados.length === 1 && uniqueMarcasEnResultados[0].toLowerCase().includes(busqueda)) {
         mostrarResultadosDeBusqueda({ type: 'marca', query: textoBusqueda, results: uniqueMarcasEnResultados });

--- a/ui.js
+++ b/ui.js
@@ -58,7 +58,7 @@ export function getLogoUrlForMarca(marca, categoria) {
         return null;
     }
 
-    const normalize = (str) => str ? str.toLowerCase().replace(/[^a-z0-9]/g, '') : '';
+    const normalize = (str) => str ? String(str).toLowerCase().replace(/[^a-z0-9]/g, '') : '';
     const normalizedMarca = normalize(marca);
     const normalizedCategoria = normalize(categoria);
 
@@ -171,10 +171,10 @@ export function mostrarCategorias() {
     mostrarUltimosAgregados();
 
     // Comentario: Se implementa el ordenamiento de categorías por población.
-    const categoriasPorPoblacion = [...new Set(cortes.map(c => c.categoria).filter(Boolean))]
+    const categoriasPorPoblacion = [...new Set(cortes.map(c => String(c.categoria)).filter(Boolean))]
         .map(cat => ({
             nombre: cat,
-            poblacion: cortes.filter(c => c.categoria === cat).length
+            poblacion: cortes.filter(c => String(c.categoria) === cat).length
         }))
         .sort((a, b) => b.poblacion - a.poblacion)
         .map(c => c.nombre);
@@ -197,7 +197,7 @@ export function mostrarCategorias() {
     });
 
     const marcasVehiculos = [...new Set(cortes
-        .filter(item => item.categoria && !['motocicletas', 'motos'].includes(item.categoria.toLowerCase()))
+        .filter(item => item.categoria && !['motocicletas', 'motos'].includes(String(item.categoria).toLowerCase()))
         .map(item => item.marca))]
         .filter(Boolean).sort();
 
@@ -217,7 +217,7 @@ export function mostrarCategorias() {
     });
 
     const marcasMotos = [...new Set(cortes
-        .filter(item => item.categoria && ['motocicletas', 'motos'].includes(item.categoria.toLowerCase()))
+        .filter(item => item.categoria && ['motocicletas', 'motos'].includes(String(item.categoria).toLowerCase()))
         .map(item => item.marca))]
         .filter(Boolean).sort();
 
@@ -291,10 +291,10 @@ export function mostrarModelosPorMarca(marca) {
     cont.innerHTML = `<span class="backBtn" onclick="${backAction}">${backSvg} Volver</span><h4>Modelos de ${marca}</h4>`;
 
     // Se filtran los cortes para obtener todos los modelos de la marca seleccionada, excluyendo motocicletas
-    const modelosFiltrados = cortes.filter(item => item.marca === marca && item.categoria && !['motocicletas', 'motos'].includes(item.categoria.toLowerCase()));
+    const modelosFiltrados = cortes.filter(item => item.marca === marca && item.categoria && !['motocicletas', 'motos'].includes(String(item.categoria).toLowerCase()));
 
     // Se obtienen modelos únicos para no repetir tarjetas
-    const modelosUnicos = [...new Map(modelosFiltrados.map(item => [item.modelo, item])).values()].sort((a,b) => a.modelo.localeCompare(b.modelo));
+    const modelosUnicos = [...new Map(modelosFiltrados.map(item => [item.modelo, item])).values()].sort((a,b) => String(a.modelo).localeCompare(String(b.modelo)));
 
     const grid = document.createElement("div");
     grid.className = "grid";
@@ -399,7 +399,7 @@ export function mostrarModelos(categoria, marca, versionEquipamiento = null) {
         modelosFiltrados = modelosFiltrados.filter(item => item.versionesAplicables === versionEquipamiento);
     }
 
-    const modelosUnicos = [...new Map(modelosFiltrados.map(item => [item.modelo, item])).values()].sort((a,b) => a.modelo.localeCompare(b.modelo));
+    const modelosUnicos = [...new Map(modelosFiltrados.map(item => [item.modelo, item])).values()].sort((a,b) => String(a.modelo).localeCompare(String(b.modelo)));
 
     // Comentario: Se elimina la lógica de omisión de pantalla. La decisión ahora se centraliza en `navegarADetallesDeModelo`.
 
@@ -943,7 +943,7 @@ function renderCutContent(container, cutData, datosRelay, vehicleId, isLazy = fa
     const relayContainer = document.createElement('p');
     const configRelay = cutData.configRelay;
 
-    if (!configRelay || configRelay.toLowerCase() === 'sin relay') {
+    if (!configRelay || String(configRelay).toLowerCase() === 'sin relay') {
         relayContainer.innerHTML = `<strong>Configuración de Relay:</strong> Sin Relay`;
     } else {
         relayContainer.innerHTML = `<strong>Configuración de Relay: </strong>`;


### PR DESCRIPTION
I have fixed the search logic to correctly handle vehicle models with numeric names (e.g., RAM 700, 3500) and improved the search experience to allow combinations of brand, model, version, ignition type, category, and year. 

Key changes:
- **navigation.js**: Updated `filtrarContenido` to ensure all vehicle properties are converted to strings during comparison. The search string now includes more metadata fields, and numeric models are no longer accidentally filtered out when searching for specific years.
- **ui.js**: Added type safety to sorting and filtering functions by wrapping numeric properties in `String()`, preventing crashes when the application attempts to call string methods on numeric model names.
- **Verification**: Validated the new logic with a dedicated Node.js test script covering numeric models, mixed searches (e.g., "RAM 700"), and multi-field searches (e.g., "Toyota Push Button 2020").

---
*PR created automatically by Jules for task [9358703872014784223](https://jules.google.com/task/9358703872014784223) started by @infogpstech*