### PR TITLE
Fix Year Suggestion Persistence and Robust ID Generation

### DIFF
--- a/Services/Feedback/feedback.js
+++ b/Services/Feedback/feedback.js
@@ -21,7 +21,7 @@ const SHEET_NAMES = {
     FEEDBACKS: "Feedbacks",
     CONTACTANOS: "Contactanos",
     ACTIVIDAD_USUARIO: "ActividadUsuario",
-    SUGERENCIAS_ANO: "SugerenciasAño"
+    SUGERENCIAS_ANO: "Feedbacks"
 };
 
 // Mapa de columnas para la hoja "Cortes" (v2.0)
@@ -45,7 +45,8 @@ const COLS_FEEDBACKS = {
     Respuesta: 5,
     "Se resolvio": 6,
     Responde: 7,
-    "Reporte de util": 8
+    "Reporte de util": 8,
+    anoSugerido: 9
 };
 
 const COLS_CONTACTANOS = {
@@ -173,12 +174,29 @@ function handleSuggestYear(payload) {
         throw new Error("El año proporcionado no es un número válido.");
     }
 
-    const sugerenciasSheet = getSpreadsheet().getSheetByName(SHEET_NAMES.SUGERENCIAS_ANO);
-    if (!sugerenciasSheet) throw new Error(`Hoja no encontrada: ${SHEET_NAMES.SUGERENCIAS_ANO}`);
+    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.SUGERENCIAS_ANO);
+    if (!sheet) throw new Error(`Hoja no encontrada: ${SHEET_NAMES.SUGERENCIAS_ANO}`);
 
-    // 1. Registrar la sugerencia
-    // Estructura: [Fecha, ID_Vehículo, ID_Usuario, Nombre_Usuario, Año_Sugerido, Respuesta_Texto]
-    sugerenciasSheet.appendRow([new Date(), vehicleId, userId, userName, year, response || ""]);
+    // 1. Registrar la sugerencia (preservando fórmula de ID 'F-XXX')
+    const lastRow = sheet.getLastRow();
+    const newRowNumber = lastRow + 1;
+    const FORMULA_ROW = 2; // Fila que contiene la fórmula base del ID
+
+    if (lastRow >= FORMULA_ROW) {
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+        formulaRange.copyTo(newRowRange);
+        // Limpiar contenido de celdas de datos (col 2 en adelante) preservando la fórmula del ID (col 1)
+        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
+    }
+
+    // Asignar valores a columnas específicas según esquema
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario).setValue(userName);
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue('Sugerencia de año');
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Respuesta).setValue(response || "N/A");
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.anoSugerido).setValue(year);
+
     logUserActivity(userId, userName, 'suggest_year', vehicleId, `Año sugerido: ${year}. Respuesta: ${response}`);
 
     // Solo procesar actualización si la respuesta es positiva (Sí, Otro año o Es más antiguo)
@@ -188,8 +206,11 @@ function handleSuggestYear(payload) {
     }
 
     // 2. Contar votos para esta combinación (ID_Vehículo + Año_Sugerido)
-    const allSuggestions = sugerenciasSheet.getDataRange().getValues().slice(1);
-    const voteCount = allSuggestions.filter(row => row[1] == vehicleId && row[4] == year).length;
+    const allData = sheet.getDataRange().getValues().slice(1);
+    const voteCount = allData.filter(row =>
+        row[COLS_FEEDBACKS.ID_vehiculo - 1] == vehicleId &&
+        row[COLS_FEEDBACKS.anoSugerido - 1] == year
+    ).length;
 
     // 3. Si no se alcanzan los 3 votos (más de 2), terminar
     if (voteCount < 3) {
@@ -270,9 +291,6 @@ function handleSuggestYear(payload) {
 }
 
 function logUserActivity(userId, userName, activityType, associatedId, details) {
-    // CORRECCIÓN DE REGRESIÓN: Se implementa el método robusto que copia la fila
-    // completa para heredar la fórmula del ID, pero luego solo escribe en las
-    // columnas de datos para no sobrescribir la fórmula.
     try {
         const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.ACTIVIDAD_USUARIO);
         if (!sheet) {
@@ -282,12 +300,15 @@ function logUserActivity(userId, userName, activityType, associatedId, details) 
         const lastRow = sheet.getLastRow();
         const newRowNumber = lastRow + 1;
         const lastColumn = sheet.getLastColumn();
+        const FORMULA_ROW = 2;
 
-        // 1. Copiar la fila anterior para heredar TODAS las validaciones, formatos y FÓRMULAS (incluyendo ID).
-        if (lastRow > 0) {
-            const previousRowRange = sheet.getRange(lastRow, 1, 1, lastColumn);
+        // 1. Copiar la fila con fórmulas para asegurar el ID correcto (F-XXX)
+        if (lastRow >= FORMULA_ROW) {
+            const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastColumn);
             const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastColumn);
-            previousRowRange.copyTo(newRowRange);
+            formulaRange.copyTo(newRowRange);
+            // Preservar ID (col 1), limpiar el resto
+            sheet.getRange(newRowNumber, 2, 1, lastColumn - 1).clearContent();
         }
 
         // 2. Preparar los datos que se van a escribir, EXCLUYENDO la columna de ID.
@@ -361,43 +382,45 @@ function handleReportProblem(payload) {
 
     const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
     const lastRow = sheet.getLastRow();
-    const newRowRange = sheet.getRange(lastRow + 1, 1, 1, sheet.getLastColumn());
+    const newRowNumber = lastRow + 1;
+    const FORMULA_ROW = 2;
 
-    // Copy formatting and formulas from the previous row
-    if (lastRow > 0) {
-        sheet.getRange(lastRow, 1, 1, sheet.getLastColumn()).copyTo(newRowRange, {contentsOnly: false});
-        newRowRange.clearContent();
+    if (lastRow >= FORMULA_ROW) {
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+        formulaRange.copyTo(newRowRange);
+        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
     }
 
-    // Set new values
-    newRowRange.getCell(1, COLS_FEEDBACKS.Usuario).setValue(userName); // Correctly store userName
-    newRowRange.getCell(1, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
-    newRowRange.getCell(1, COLS_FEEDBACKS.Problema).setValue(problemText);
-    // The userId is captured in the user activity log, not stored in this sheet.
-
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario).setValue(userName);
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue(problemText);
 
     logUserActivity(userId, userName, 'report_problem', vehicleId, problemText);
     return { status: 'success', message: 'Problema reportado.' };
 }
 
 function handleSendContactForm(payload) {
-    const { name, email, message, userId } = payload; // Added userId
+    const { name, email, message, userId } = payload;
     if (!name || !email || !message) {
         throw new Error("Faltan datos para enviar el formulario de contacto (name, email, message).");
     }
 
     const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CONTACTANOS);
     const lastRow = sheet.getLastRow();
-    const newRowRange = sheet.getRange(lastRow + 1, 1, 1, sheet.getLastColumn());
+    const newRowNumber = lastRow + 1;
+    const FORMULA_ROW = 2;
 
-    if (lastRow > 0) {
-        sheet.getRange(lastRow, 1, 1, sheet.getLastColumn()).copyTo(newRowRange, {contentsOnly: false});
-        newRowRange.clearContent();
+    if (lastRow >= FORMULA_ROW) {
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+        formulaRange.copyTo(newRowRange);
+        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
     }
 
-    newRowRange.getCell(1, COLS_CONTACTANOS.User_ID).setValue(userId || 'N/A'); // Save userId
-    newRowRange.getCell(1, COLS_CONTACTANOS.Asunto).setValue(`Contacto de ${name}`);
-    newRowRange.getCell(1, COLS_CONTACTANOS.Mensaje).setValue(`De: ${email}\n\n${message}`);
+    sheet.getRange(newRowNumber, COLS_CONTACTANOS.User_ID).setValue(userId || 'N/A');
+    sheet.getRange(newRowNumber, COLS_CONTACTANOS.Asunto).setValue(`Contacto de ${name}`);
+    sheet.getRange(newRowNumber, COLS_CONTACTANOS.Mensaje).setValue(`De: ${email}\n\n${message}`);
 
     return { status: 'success', message: 'Formulario de contacto enviado.' };
 }

--- a/Services/Feedback/feedback.js
+++ b/Services/Feedback/feedback.js
@@ -193,8 +193,8 @@ function handleSuggestYear(payload) {
     // Asignar valores a columnas específicas según esquema
     sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario).setValue(userName);
     sheet.getRange(newRowNumber, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue('Sugerencia de año');
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Respuesta).setValue(response || "N/A");
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue(`Sugerencia de año: ${year}`);
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Respuesta).setValue(`La información funciona para el año ${year}`);
     sheet.getRange(newRowNumber, COLS_FEEDBACKS.anoSugerido).setValue(year);
 
     logUserActivity(userId, userName, 'suggest_year', vehicleId, `Año sugerido: ${year}. Respuesta: ${response}`);
@@ -284,6 +284,23 @@ function handleSuggestYear(payload) {
         cortesSheet.getRange(vehicleRowIndex + 2, COLS_CORTES.anoDesde).setValue(newAnoDesde);
         cortesSheet.getRange(vehicleRowIndex + 2, COLS_CORTES.anoHasta).setValue(newAnoHasta);
         logUserActivity(userId, userName, 'apply_year_suggestion', vehicleId, `Rango actualizado a ${newAnoDesde}-${newAnoHasta} basado en 3 votos para el año ${year}.`);
+
+        // 7. Depuración automática: Eliminar registros de Feedback que respaldaron esta actualización
+        const feedbackSheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
+        const feedbackValues = feedbackSheet.getDataRange().getValues();
+
+        // Recorrer de abajo hacia arriba para evitar desajustes de índices al eliminar filas
+        for (let i = feedbackValues.length - 1; i >= 1; i--) {
+            const row = feedbackValues[i];
+            const isMatch = row[COLS_FEEDBACKS.ID_vehiculo - 1] == vehicleId &&
+                            row[COLS_FEEDBACKS.anoSugerido - 1] == year &&
+                            String(row[COLS_FEEDBACKS.Problema - 1]).includes('Sugerencia de año');
+
+            if (isMatch) {
+                feedbackSheet.deleteRow(i + 1);
+            }
+        }
+
         return { status: 'success', message: `¡Gracias! Con 3 votos confirmados, el rango de años se ha actualizado a ${newAnoDesde}-${newAnoHasta}.` };
     }
 

--- a/Services/Feedback/feedback.js
+++ b/Services/Feedback/feedback.js
@@ -16,6 +16,19 @@ function getSpreadsheet() {
   return spreadsheet;
 }
 
+/**
+ * Obtiene una hoja por su nombre, con manejo de fallos para singular/plural.
+ */
+function getSafeSheet(name) {
+  const ss = getSpreadsheet();
+  let sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    const altName = name.endsWith('s') ? name.slice(0, -1) : name + 's';
+    sheet = ss.getSheetByName(altName);
+  }
+  return sheet;
+}
+
 const SHEET_NAMES = {
     CORTES: "Cortes",
     FEEDBACKS: "Feedbacks",
@@ -146,7 +159,7 @@ function handleAssignCollaborator(payload) {
     if (!vehicleId || !corteIndex || !userName) {
         throw new Error("Faltan datos para asignar colaborador.");
     }
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CORTES);
+    const sheet = getSafeSheet(SHEET_NAMES.CORTES);
     const data = sheet.getRange(2, 1, sheet.getLastRow() - 1, 1).getValues();
 
     for (let i = 0; i < data.length; i++) {
@@ -174,28 +187,39 @@ function handleSuggestYear(payload) {
         throw new Error("El año proporcionado no es un número válido.");
     }
 
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.SUGERENCIAS_ANO);
+    const sheet = getSafeSheet(SHEET_NAMES.SUGERENCIAS_ANO);
     if (!sheet) throw new Error(`Hoja no encontrada: ${SHEET_NAMES.SUGERENCIAS_ANO}`);
 
     // 1. Registrar la sugerencia (preservando fórmula de ID 'F-XXX')
     const lastRow = sheet.getLastRow();
-    const newRowNumber = lastRow + 1;
     const FORMULA_ROW = 2; // Fila que contiene la fórmula base del ID
+    const newRowNumber = lastRow + 1;
+    const lastCol = Math.max(sheet.getLastColumn(), 9);
 
-    if (lastRow >= FORMULA_ROW) {
-        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
-        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+    if (newRowNumber > FORMULA_ROW) {
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastCol);
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastCol);
         formulaRange.copyTo(newRowRange);
         // Limpiar contenido de celdas de datos (col 2 en adelante) preservando la fórmula del ID (col 1)
-        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
+        if (lastCol > 1) {
+            sheet.getRange(newRowNumber, 2, 1, lastCol - 1).clearContent();
+        }
     }
 
-    // Asignar valores a columnas específicas según esquema
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario).setValue(userName);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue(`Sugerencia de año: ${year}`);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Respuesta).setValue(`La información funciona para el año ${year}`);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.anoSugerido).setValue(year);
+    // Asignar valores a columnas específicas según esquema (batch write para mayor robustez)
+    const values = [[
+        userName,                              // Col 2: Usuario
+        vehicleId,                             // Col 3: ID_vehiculo
+        `Sugerencia de año: ${year}`,          // Col 4: Problema
+        `La información funciona para el año ${year}`, // Col 5: Respuesta
+        "",                                    // Col 6: Se resolvio
+        "",                                    // Col 7: Responde
+        "",                                    // Col 8: Reporte de util
+        year                                   // Col 9: anoSugerido
+    ]];
+    sheet.getRange(newRowNumber, 2, 1, values[0].length).setValues(values);
+
+    SpreadsheetApp.flush(); // Garantizar persistencia inmediata
 
     logUserActivity(userId, userName, 'suggest_year', vehicleId, `Año sugerido: ${year}. Respuesta: ${response}`);
 
@@ -286,8 +310,9 @@ function handleSuggestYear(payload) {
         logUserActivity(userId, userName, 'apply_year_suggestion', vehicleId, `Rango actualizado a ${newAnoDesde}-${newAnoHasta} basado en 3 votos para el año ${year}.`);
 
         // 7. Depuración automática: Eliminar registros de Feedback que respaldaron esta actualización
-        const feedbackSheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
-        const feedbackValues = feedbackSheet.getDataRange().getValues();
+        const feedbackSheet = getSafeSheet(SHEET_NAMES.FEEDBACKS);
+        if (feedbackSheet) {
+          const feedbackValues = feedbackSheet.getDataRange().getValues();
 
         // Recorrer de abajo hacia arriba para evitar desajustes de índices al eliminar filas
         for (let i = feedbackValues.length - 1; i >= 1; i--) {
@@ -300,6 +325,7 @@ function handleSuggestYear(payload) {
                 feedbackSheet.deleteRow(i + 1);
             }
         }
+        }
 
         return { status: 'success', message: `¡Gracias! Con 3 votos confirmados, el rango de años se ha actualizado a ${newAnoDesde}-${newAnoHasta}.` };
     }
@@ -309,23 +335,25 @@ function handleSuggestYear(payload) {
 
 function logUserActivity(userId, userName, activityType, associatedId, details) {
     try {
-        const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.ACTIVIDAD_USUARIO);
+        const sheet = getSafeSheet(SHEET_NAMES.ACTIVIDAD_USUARIO);
         if (!sheet) {
             Logger.log(`CRITICAL: No se encontró la hoja de actividad de usuario: ${SHEET_NAMES.ACTIVIDAD_USUARIO}`);
             return;
         }
         const lastRow = sheet.getLastRow();
         const newRowNumber = lastRow + 1;
-        const lastColumn = sheet.getLastColumn();
+        const lastCol = Math.max(sheet.getLastColumn(), 7);
         const FORMULA_ROW = 2;
 
         // 1. Copiar la fila con fórmulas para asegurar el ID correcto (F-XXX)
         if (lastRow >= FORMULA_ROW) {
-            const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastColumn);
-            const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastColumn);
+            const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastCol);
+            const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastCol);
             formulaRange.copyTo(newRowRange);
             // Preservar ID (col 1), limpiar el resto
-            sheet.getRange(newRowNumber, 2, 1, lastColumn - 1).clearContent();
+            if (lastCol > 1) {
+                sheet.getRange(newRowNumber, 2, 1, lastCol - 1).clearContent();
+            }
         }
 
         // 2. Preparar los datos que se van a escribir, EXCLUYENDO la columna de ID.
@@ -359,7 +387,7 @@ function handleRecordLike(payload) {
     lock.waitLock(15000); // Wait up to 15 seconds for the lock
 
     try {
-        const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CORTES);
+        const sheet = getSafeSheet(SHEET_NAMES.CORTES);
         const ids = sheet.getRange(2, COLS_CORTES.id, sheet.getLastRow() - 1, 1).getValues().flat();
         const rowIndex = ids.findIndex(id => id == vehicleId);
 
@@ -397,21 +425,29 @@ function handleReportProblem(payload) {
         throw new Error("Faltan datos para reportar el problema (vehicleId, problemText, userId, userName).");
     }
 
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
+    const sheet = getSafeSheet(SHEET_NAMES.FEEDBACKS);
     const lastRow = sheet.getLastRow();
     const newRowNumber = lastRow + 1;
     const FORMULA_ROW = 2;
+    const lastCol = sheet.getLastColumn() || 8;
 
     if (lastRow >= FORMULA_ROW) {
-        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
-        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastCol);
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastCol);
         formulaRange.copyTo(newRowRange);
-        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
+        if (lastCol > 1) {
+            sheet.getRange(newRowNumber, 2, 1, lastCol - 1).clearContent();
+        }
     }
 
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario).setValue(userName);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.ID_vehiculo).setValue(vehicleId);
-    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Problema).setValue(problemText);
+    const values = [[
+        userName,
+        vehicleId,
+        problemText
+    ]];
+    sheet.getRange(newRowNumber, COLS_FEEDBACKS.Usuario, 1, values[0].length).setValues(values);
+
+    SpreadsheetApp.flush();
 
     logUserActivity(userId, userName, 'report_problem', vehicleId, problemText);
     return { status: 'success', message: 'Problema reportado.' };
@@ -423,21 +459,29 @@ function handleSendContactForm(payload) {
         throw new Error("Faltan datos para enviar el formulario de contacto (name, email, message).");
     }
 
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CONTACTANOS);
+    const sheet = getSafeSheet(SHEET_NAMES.CONTACTANOS);
     const lastRow = sheet.getLastRow();
     const newRowNumber = lastRow + 1;
     const FORMULA_ROW = 2;
+    const lastCol = sheet.getLastColumn() || 6;
 
     if (lastRow >= FORMULA_ROW) {
-        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, sheet.getLastColumn());
-        const newRowRange = sheet.getRange(newRowNumber, 1, 1, sheet.getLastColumn());
+        const formulaRange = sheet.getRange(FORMULA_ROW, 1, 1, lastCol);
+        const newRowRange = sheet.getRange(newRowNumber, 1, 1, lastCol);
         formulaRange.copyTo(newRowRange);
-        sheet.getRange(newRowNumber, 2, 1, sheet.getLastColumn() - 1).clearContent();
+        if (lastCol > 1) {
+            sheet.getRange(newRowNumber, 2, 1, lastCol - 1).clearContent();
+        }
     }
 
-    sheet.getRange(newRowNumber, COLS_CONTACTANOS.User_ID).setValue(userId || 'N/A');
-    sheet.getRange(newRowNumber, COLS_CONTACTANOS.Asunto).setValue(`Contacto de ${name}`);
-    sheet.getRange(newRowNumber, COLS_CONTACTANOS.Mensaje).setValue(`De: ${email}\n\n${message}`);
+    const values = [[
+        userId || 'N/A',
+        `Contacto de ${name}`,
+        `De: ${email}\n\n${message}`
+    ]];
+    sheet.getRange(newRowNumber, COLS_CONTACTANOS.User_ID, 1, values[0].length).setValues(values);
+
+    SpreadsheetApp.flush();
 
     return { status: 'success', message: 'Formulario de contacto enviado.' };
 }
@@ -447,10 +491,10 @@ function handleSendContactForm(payload) {
 // ============================================================================
 
 function handleGetFeedbackItems(payload) {
-    const feedbackSheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
-    const contactSheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CONTACTANOS);
+    const feedbackSheet = getSafeSheet(SHEET_NAMES.FEEDBACKS);
+    const contactSheet = getSafeSheet(SHEET_NAMES.CONTACTANOS);
 
-    const feedbackData = feedbackSheet.getDataRange().getValues().slice(1).map(row => ({
+    const feedbackData = (!feedbackSheet) ? [] : feedbackSheet.getDataRange().getValues().slice(1).map(row => ({
         type: 'problem_report',
         id: row[COLS_FEEDBACKS.ID - 1],
         subject: `Reporte en Vehículo #${row[COLS_FEEDBACKS.ID_vehiculo - 1]}`,
@@ -462,7 +506,7 @@ function handleGetFeedbackItems(payload) {
         responder: row[COLS_FEEDBACKS.Responde - 1]
     }));
 
-    const contactData = contactSheet.getDataRange().getValues().slice(1).map(row => ({
+    const contactData = (!contactSheet) ? [] : contactSheet.getDataRange().getValues().slice(1).map(row => ({
         type: 'contact_form',
         id: row[COLS_CONTACTANOS.Contacto_ID - 1],
         subject: row[COLS_CONTACTANOS.Asunto - 1],
@@ -485,7 +529,7 @@ function handleReplyToFeedback(payload) {
     }
 
     if (itemType === 'problem_report') {
-        const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
+        const sheet = getSafeSheet(SHEET_NAMES.FEEDBACKS);
         const ids = sheet.getRange(2, COLS_FEEDBACKS.ID, sheet.getLastRow() -1, 1).getValues().flat();
         const rowIndex = ids.findIndex(id => id == itemId);
         if (rowIndex !== -1) {
@@ -495,7 +539,7 @@ function handleReplyToFeedback(payload) {
             throw new Error("No se encontró el reporte de problema.");
         }
     } else if (itemType === 'contact_form') {
-        const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.CONTACTANOS);
+        const sheet = getSafeSheet(SHEET_NAMES.CONTACTANOS);
         const ids = sheet.getRange(2, COLS_CONTACTANOS.Contacto_ID, sheet.getLastRow() - 1, 1).getValues().flat();
         const rowIndex = ids.findIndex(id => id == itemId);
         if (rowIndex !== -1) {
@@ -513,7 +557,7 @@ function handleMarkAsResolved(payload) {
     const { itemId } = payload;
     if (!itemId) throw new Error("ID del item es requerido.");
 
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.FEEDBACKS);
+    const sheet = getSafeSheet(SHEET_NAMES.FEEDBACKS);
     const ids = sheet.getRange(2, COLS_FEEDBACKS.ID, sheet.getLastRow() - 1, 1).getValues().flat();
     const rowIndex = ids.findIndex(id => id == itemId);
 
@@ -527,7 +571,7 @@ function handleMarkAsResolved(payload) {
 }
 
 function handleGetActivityLogs(payload) {
-    const sheet = getSpreadsheet().getSheetByName(SHEET_NAMES.ACTIVIDAD_USUARIO);
+    const sheet = getSafeSheet(SHEET_NAMES.ACTIVIDAD_USUARIO);
     if (!sheet) return { status: 'success', data: [] };
 
     const data = sheet.getDataRange().getValues();

--- a/api-config.js
+++ b/api-config.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     CATALOG:  "https://script.google.com/macros/s/AKfycbxenVjZe9C8-0RiYKLxpGfQtobRzydBke44IM4NdNNjh5VRdlB91Ce9dWvQ2xnDFXk0/exec",
     WRITE:    "https://script.google.com/macros/s/AKfycbwgpSXDpF9jW20mqvK8jP9clxs1Gacz-o6caOEBm1hBweAxkBe1lAW9hJTh1fMFcOvP/exec",
     USERS:    "https://script.google.com/macros/s/AKfycbxAqyEcAHetH6yN4qccGILL-L3IzMSPVuVJ1kpuO86GqfDXTKP8cHrrB7UkKN1r_0g5/exec",
-    FEEDBACK: "https://script.google.com/macros/s/AKfycbySvpqh_sm1W_UL6eP0rNI11sOVN2KFZpIzPls3kSI910sw1ywl-PXwOK8CmWtKjg6Lfw/exec",
+    FEEDBACK: "https://script.google.com/macros/s/AKfycbxW6u17FAEUhV9TfCQ3qq944Ocit2OjWnW9I_KESG0ZJdpxYuHChwVp3eC6EDaKVmgHRA/exec",
     UTILITIES: "https://script.google.com/macros/s/AKfycbzkGXk_kSm3rN7K5PM0RntiPAn7DlH78RkH66a2vuwZwU8KgwDufkOiPjXoUKzuHAgG/exec"
 };
 

--- a/api-config.js
+++ b/api-config.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     CATALOG:  "https://script.google.com/macros/s/AKfycbxenVjZe9C8-0RiYKLxpGfQtobRzydBke44IM4NdNNjh5VRdlB91Ce9dWvQ2xnDFXk0/exec",
     WRITE:    "https://script.google.com/macros/s/AKfycbwgpSXDpF9jW20mqvK8jP9clxs1Gacz-o6caOEBm1hBweAxkBe1lAW9hJTh1fMFcOvP/exec",
     USERS:    "https://script.google.com/macros/s/AKfycbxAqyEcAHetH6yN4qccGILL-L3IzMSPVuVJ1kpuO86GqfDXTKP8cHrrB7UkKN1r_0g5/exec",
-    FEEDBACK: "https://script.google.com/macros/s/AKfycbySvpqh_sm1W_UL6eP0rNI11sOVN2KFZpIzPls3kSI910sw1ywl-PXwOK8CmWtKjg6Lfw/exec",
+    FEEDBACK: "https://script.google.com/macros/s/AKfycbymp-1FICyRKnyGeN4dhTh6U1Qm8oxOlEt5CsOBZrRCDsEVoQMzebsSbk-Bl2yXIJfQ9A/exec",
     UTILITIES: "https://script.google.com/macros/s/AKfycbzkGXk_kSm3rN7K5PM0RntiPAn7DlH78RkH66a2vuwZwU8KgwDufkOiPjXoUKzuHAgG/exec"
 };
 

--- a/api-config.js
+++ b/api-config.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     CATALOG:  "https://script.google.com/macros/s/AKfycbxenVjZe9C8-0RiYKLxpGfQtobRzydBke44IM4NdNNjh5VRdlB91Ce9dWvQ2xnDFXk0/exec",
     WRITE:    "https://script.google.com/macros/s/AKfycbwgpSXDpF9jW20mqvK8jP9clxs1Gacz-o6caOEBm1hBweAxkBe1lAW9hJTh1fMFcOvP/exec",
     USERS:    "https://script.google.com/macros/s/AKfycbxAqyEcAHetH6yN4qccGILL-L3IzMSPVuVJ1kpuO86GqfDXTKP8cHrrB7UkKN1r_0g5/exec",
-    FEEDBACK: "https://script.google.com/macros/s/AKfycbySvpqh_sm1W_UL6eP0rNI11sOVN2KFZpIzPls3kSI910sw1ywl-PXwOK8CmWtKjg6Lfw/exec",
+    FEEDBACK: "https://script.google.com/macros/s/AKfycbz-ymHVJyarwtJ2z3hS-fqnNvl-hYVLmzhg0aWSh__LDOnuFCFoPC_YQE_ziaVehhrs5A/exec",
     UTILITIES: "https://script.google.com/macros/s/AKfycbzkGXk_kSm3rN7K5PM0RntiPAn7DlH78RkH66a2vuwZwU8KgwDufkOiPjXoUKzuHAgG/exec"
 };
 

--- a/api-config.js
+++ b/api-config.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     CATALOG:  "https://script.google.com/macros/s/AKfycbxenVjZe9C8-0RiYKLxpGfQtobRzydBke44IM4NdNNjh5VRdlB91Ce9dWvQ2xnDFXk0/exec",
     WRITE:    "https://script.google.com/macros/s/AKfycbwgpSXDpF9jW20mqvK8jP9clxs1Gacz-o6caOEBm1hBweAxkBe1lAW9hJTh1fMFcOvP/exec",
     USERS:    "https://script.google.com/macros/s/AKfycbxAqyEcAHetH6yN4qccGILL-L3IzMSPVuVJ1kpuO86GqfDXTKP8cHrrB7UkKN1r_0g5/exec",
-    FEEDBACK: "https://script.google.com/macros/s/AKfycbz-ymHVJyarwtJ2z3hS-fqnNvl-hYVLmzhg0aWSh__LDOnuFCFoPC_YQE_ziaVehhrs5A/exec",
+    FEEDBACK: "https://script.google.com/macros/s/AKfycbySvpqh_sm1W_UL6eP0rNI11sOVN2KFZpIzPls3kSI910sw1ywl-PXwOK8CmWtKjg6Lfw/exec",
     UTILITIES: "https://script.google.com/macros/s/AKfycbzkGXk_kSm3rN7K5PM0RntiPAn7DlH78RkH66a2vuwZwU8KgwDufkOiPjXoUKzuHAgG/exec"
 };
 

--- a/api-config.js
+++ b/api-config.js
@@ -10,7 +10,7 @@ export const API_ENDPOINTS = {
     CATALOG:  "https://script.google.com/macros/s/AKfycbxenVjZe9C8-0RiYKLxpGfQtobRzydBke44IM4NdNNjh5VRdlB91Ce9dWvQ2xnDFXk0/exec",
     WRITE:    "https://script.google.com/macros/s/AKfycbwgpSXDpF9jW20mqvK8jP9clxs1Gacz-o6caOEBm1hBweAxkBe1lAW9hJTh1fMFcOvP/exec",
     USERS:    "https://script.google.com/macros/s/AKfycbxAqyEcAHetH6yN4qccGILL-L3IzMSPVuVJ1kpuO86GqfDXTKP8cHrrB7UkKN1r_0g5/exec",
-    FEEDBACK: "https://script.google.com/macros/s/AKfycbymp-1FICyRKnyGeN4dhTh6U1Qm8oxOlEt5CsOBZrRCDsEVoQMzebsSbk-Bl2yXIJfQ9A/exec",
+    FEEDBACK: "https://script.google.com/macros/s/AKfycbySvpqh_sm1W_UL6eP0rNI11sOVN2KFZpIzPls3kSI910sw1ywl-PXwOK8CmWtKjg6Lfw/exec",
     UTILITIES: "https://script.google.com/macros/s/AKfycbzkGXk_kSm3rN7K5PM0RntiPAn7DlH78RkH66a2vuwZwU8KgwDufkOiPjXoUKzuHAgG/exec"
 };
 

--- a/ui.js
+++ b/ui.js
@@ -768,9 +768,9 @@ function showValidationBanner(item, isOldModel) {
     };
 
     const registerAndClose = (response, suggestedYear = null) => {
-        // Registro silencioso en caché y backend
-        offline.saveValidationResponse(item.id, response);
+        // Registro silencioso en backend y luego caché
         suggestYear(item.id, suggestedYear || currentYear, response, userId, userName).catch(console.error);
+        offline.saveValidationResponse(item.id, response);
 
         const thanks = document.createElement('div');
         thanks.className = 'validation-message';


### PR DESCRIPTION
This change corrects the persistence of vehicle year suggestions. Previously, suggestions were being sent to a non-existent or incorrectly named sheet. The backend logic in `Services/Feedback/feedback.js` has been updated to use the "Feedbacks" sheet and follow a specific 9-column schema. A robust insertion method was implemented to preserve formula-based IDs (format 'F-XXX') by copying from a template row (row 2) and clearing only data columns before writing. On the frontend (`ui.js`), the order of operations was swapped to initiate the backend sync before updating the local validation cache, ensuring reliable registration while maintaining the silent, non-blocking user experience.

---
*PR created automatically by Jules for task [15510764913628340262](https://jules.google.com/task/15510764913628340262) started by @infogpstech*