### PR TITLE
Fix automatic modal opening and card rendering for single results

### DIFF
--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -29,3 +29,29 @@
 - El año actual para 2026 debe ser dinámico o constante según se prefiera, pero el prompt usa 2026 como ejemplo. Usaré `new Date().getFullYear()`.
 
 --------------------------------------------------
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - Diagnóstico de bug en apertura automática del modal (24/06/2026)**
+
+**Archivos involucrados:** ui.js, navigation.js, main.js.
+
+**Hallazgos:**
+1. **ui.js (mostrarResultadosDeBusqueda):**
+   - El bloque condicional para resultados únicos (`results.length === 1`) invoca a `mostrarDetalleModal` pero realiza un `return` inmediato.
+   - Este `return` interrumpe el flujo de renderizado, impidiendo que se cree la cuadrícula (`grid`) y la tarjeta (`card`) del vehículo en la vista de resultados.
+   - Impacto: El usuario ve el modal (si no se cierra) pero al cerrarlo la lista de resultados está vacía (solo el título).
+
+2. **navigation.js (filtrarContenido):**
+   - La actualización del hash de la URL (`window.location.hash`) ocurre al final de la función, después de haber renderizado los resultados y abierto el modal.
+   - El cambio de hash dispara un evento `popstate` que es procesado por el listener global en `main.js`.
+
+3. **main.js (popstate listener):**
+   - El listener de `popstate` cierra automáticamente cualquier modal de detalle visible (`#modalDetalle.visible`) para soportar la navegación con el botón "Atrás".
+   - Debido a que el hash se actualiza después de abrir el modal, el evento `popstate` resultante cierra el modal inmediatamente después de que se abre.
+   - Esto explica por qué el vehículo se registra en "Vistos recientemente" (la función se ejecuta) pero el modal no permanece visible.
+
+**Acciones Correctoras:**
+- **ui.js:** Eliminar el `return` en el bloque de resultado único de `mostrarResultadosDeBusqueda` para permitir el renderizado completo de la UI.
+- **navigation.js:** Reordenar la ejecución para actualizar el hash de la URL antes de invocar el renderizado de resultados, evitando la colisión de eventos de historial con la apertura del modal.
+
+--------------------------------------------------

--- a/ChangesLogs.txt
+++ b/ChangesLogs.txt
@@ -417,3 +417,13 @@ Archivos modificados:
 - ui.js: L689-726, L728-898, L1216-1229. Implementada lógica de elegibilidad, flujo de preguntas, renderizado del banner e integración con evento onload de imágenes.
 - Services/Feedback/feedback.js: L166, L180-191. Refinada lógica de backend para procesar respuestas de validación y condicionar la actualización automática a votos positivos.
 --------------------------------------------------
+
+**CHANGES LOG - 06/07/2026**
+
+**Archivo: ui.js**
+- **Línea 1014:** Eliminado el `return;` en la función `mostrarResultadosDeBusqueda` para permitir que la cuadrícula de resultados se renderice completamente incluso cuando se abre el modal automáticamente para un único resultado.
+
+**Archivo: navigation.js**
+- **Líneas 111-115:** Reordenada la lógica en `filtrarContenido` para actualizar el estado de navegación (`setState`) y el hash de la URL (`window.location.hash`) antes de invocar el renderizado de resultados. Esto previene que el evento `popstate` cierre prematuramente el modal de detalle automático.
+
+**Versión:** Incremento a v2.4.7 (Corrección de apertura de modal).

--- a/Instrucciones.txt
+++ b/Instrucciones.txt
@@ -307,3 +307,8 @@ Cualquier cambio en estas zonas invalidará el commit.
 6. TÍTULO: Dashboard de Desempeño para Supervisores (PENDIENTE)
 7. TÍTULO: Funcionalidad de Edición 'In-Modal' (PENDIENTE)
 8. TÍTULO: Lógica de Backend para Feedback Inbox (PENDIENTE)
+
+1. **TÍTULO: Diagnóstico y corrección de la apertura automática del modal (v2.4.7)**
+   - **ESTADO:** COMPLETADO
+   - **ALCANCE:** ui.js, navigation.js
+   - **DESCRIPCIÓN DETALLADA:** Corregido el fallo que impedía renderizar la tarjeta y mantenía el modal cerrado al obtener un único resultado de búsqueda. Se eliminó el retorno prematuro en `ui.js` y se reordenó la actualización del hash en `navigation.js` para evitar colisiones con el listener de `popstate` en `main.js`.

--- a/navigation.js
+++ b/navigation.js
@@ -107,6 +107,13 @@ export function filtrarContenido(textoBusqueda) {
         }
     }, 1500);
 
+    // Se guarda el término de búsqueda en el estado para permitir la navegación hacia atrás.
+    setState({ navigationState: { level: "busqueda", query: textoBusqueda } });
+
+    // Actualizar el hash para Deep Linking ANTES de renderizar resultados.
+    // Esto evita que el evento popstate cierre el modal de detalle cuando se abre automáticamente (resultado único).
+    window.location.hash = `search=${encodeURIComponent(textoBusqueda)}`;
+
     // --- LÓGICA DE CLASIFICACIÓN MEJORADA (BASADA EN RESULTADOS) ---
     const uniqueMarcasEnResultados = [...new Set(datosFiltrados.map(item => item.marca))];
 
@@ -121,10 +128,4 @@ export function filtrarContenido(textoBusqueda) {
         // Se elimina la de-duplicación para mostrar todas las versiones.
         mostrarResultadosDeBusqueda({ type: 'modelo', query: textoBusqueda, results: datosFiltrados });
     }
-
-    // Se guarda el término de búsqueda en el estado para permitir la navegación hacia atrás.
-    setState({ navigationState: { level: "busqueda", query: textoBusqueda } });
-
-    // Actualizar el hash para Deep Linking
-    window.location.hash = `search=${encodeURIComponent(textoBusqueda)}`;
 }

--- a/ui.js
+++ b/ui.js
@@ -1011,7 +1011,6 @@ export function mostrarResultadosDeBusqueda({ type, query, results }) {
     // Caso especial: Si solo hay un resultado de modelo, se muestra directamente el modal de detalle.
     if (type === 'modelo' && results.length === 1) {
         mostrarDetalleModal(results[0]);
-        return;
     }
 
     const grid = document.createElement("div");


### PR DESCRIPTION
This PR fixes a bug where, upon performing a search that returns exactly one result, the vehicle card was not rendered in the background and the detail modal was closed immediately after opening.

Key changes:
1. **ui.js**: Removed a `return` statement in `mostrarResultadosDeBusqueda` that was preventing the results grid from being rendered when a single result was found.
2. **navigation.js**: Moved the `window.location.hash` and `setState` updates before calling the rendering functions. This ensures the URL state is updated before the modal opens, preventing the global `popstate` listener in `main.js` (which manages modal closing for "Back" navigation) from closing the modal due to a race condition.
3. **Documentation**: Updated audit trails, change logs, and task instructions as required.

Verification:
- Manual and automated verification using Playwright confirmed that the card is now visible in the background and the modal stays open for single-result searches.
- Multiple-result and no-result search behaviors remain unchanged.
- Recently viewed history updates correctly.

---
*PR created automatically by Jules for task [14205993300395807125](https://jules.google.com/task/14205993300395807125) started by @infogpstech*