### PR TITLE
Fine-Tune Navigation and Virtual Keyboard Back Gesture Handling

### DIFF
--- a/Auditoria.txt
+++ b/Auditoria.txt
@@ -558,3 +558,16 @@ El Corte Recomendado no carga su imagen porque `renderCutContent` le asigna `dat
 - **Hallazgo:** Cuando el input de búsqueda está enfocado y se realiza un retroceso, el navegador ya ha retrocedido un estado en el historial (dejando activo el estado anterior, p. ej. "categorias").
 - El código anterior re-insertaba el estado actual ya modificado (state), duplicando el estado de la página de inicio en lugar de preservar el estado de búsqueda activo ({ level: "busqueda", query: currentQuery }). Esto causaba que la búsqueda se borrara del historial y el siguiente retroceso cerrara la aplicación.
 - **Acción:** Re-insertar explícitamente el estado de búsqueda { level: "busqueda", query: currentQuery } reconstruido dinámicamente con el valor del input, preservando el historial y permitiendo que el segundo retroceso regrese correctamente a la página principal.
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - REFINAMIENTO POST-COMMIT DEL HISTORIAL DE BÚSQUEDA (14/07/2026)**
+
+**Archivos: main.js, ui.js, navigation.js**
+- **Hallazgo:** Se identificó que la barra de búsqueda en estado enfocado (teclado abierto) y desenfocado (teclado cerrado) compartían el mismo estado de historial "busqueda". Esto causaba una duplicación en la pila de historial cuando el usuario utilizaba el gesto de retroceso para desenfocar la barra de búsqueda, impidiendo regresar a la página principal en el segundo retroceso.
+- **Acción:**
+  1. Introducido el nuevo estado de historial "busqueda_focused" para representar la barra de búsqueda enfocada / teclado abierto.
+  2. Al enfocar o escribir, el estado se establece en "busqueda_focused".
+  3. Al desenfocar (blur), el estado se reemplaza silenciosamente con "busqueda" (desenfocado).
+  4. En el primer retroceso (si está enfocado), se ejecuta blur() de inmediato, se elimina la clase "search-active" sin desfase de tiempo, y se re-inserta el estado "busqueda".
+  5. En el segundo retroceso, se vuelve correctamente al estado inicial sin duplicaciones ni cierres de aplicación.
+  6. Soportados ambos escenarios (Resultados múltiples y Modal de resultado único) con perfecta correspondencia en la pila de navegación del navegador y gestos del sistema.

--- a/Auditoria.txt
+++ b/Auditoria.txt
@@ -550,3 +550,11 @@ El Corte Recomendado no carga su imagen porque `renderCutContent` le asigna `dat
 **Solución:**
 - Reordenar el listener de 'popstate' en 'main.js' para que el cierre de componentes UI (Modales, Side Menu, Lightbox) tenga prioridad absoluta sobre la restauración del buscador.
 - Asegurar que la restauración de búsqueda solo ocurra si no hay overlays activos.
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - CORRECCIÓN AJUSTE POST-COMMIT DE HISTORIAL (14/07/2026)**
+
+**Archivo: main.js (popstate)**
+- **Hallazgo:** Cuando el input de búsqueda está enfocado y se realiza un retroceso, el navegador ya ha retrocedido un estado en el historial (dejando activo el estado anterior, p. ej. "categorias").
+- El código anterior re-insertaba el estado actual ya modificado (state), duplicando el estado de la página de inicio en lugar de preservar el estado de búsqueda activo ({ level: "busqueda", query: currentQuery }). Esto causaba que la búsqueda se borrara del historial y el siguiente retroceso cerrara la aplicación.
+- **Acción:** Re-insertar explícitamente el estado de búsqueda { level: "busqueda", query: currentQuery } reconstruido dinámicamente con el valor del input, preservando el historial y permitiendo que el segundo retroceso regrese correctamente a la página principal.

--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -110,3 +110,7 @@
 - Implementar `pushState` en todas las funciones de cambio de nivel en `ui.js`.
 - Actualizar el listener de `popstate` en `main.js` para manejar la reconstrucción de vistas basadas en el estado del historial (level, marca, modelo, categoria, etc.).
 - Asegurar que `irAPaginaPrincipal` sea el ancla base del historial.
+
+### CORRECCIÓN DE NAVEGACIÓN Y TECLADO VIRTUAL
+- Implementada interceptación de popstate para cerrar el teclado virtual mediante blur() sin retroceder en el historial en el primer gesto.
+- Agregado el campo 'origin' ('marca' o 'categoria') en el navigationState y en history.pushState para mantener independientes los contextos de navegación y evitar mezclar rutas en el retroceso.

--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -114,3 +114,19 @@
 ### CORRECCIÓN DE NAVEGACIÓN Y TECLADO VIRTUAL
 - Implementada interceptación de popstate para cerrar el teclado virtual mediante blur() sin retroceder en el historial en el primer gesto.
 - Agregado el campo 'origin' ('marca' o 'categoria') en el navigationState y en history.pushState para mantener independientes los contextos de navegación y evitar mezclar rutas en el retroceso.
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - CORRECCIÓN AJUSTE POST-COMMIT DE HISTORIAL (14/07/2026)**
+
+**Archivo: main.js (popstate)**
+- **Hallazgo:** Cuando el input de búsqueda está enfocado y se realiza un retroceso, el navegador ya ha retrocedido un estado en el historial (dejando activo el estado anterior, p. ej. 'categorias').
+- El código actual re-insertaba el estado actual ya modificado (), duplicando el estado de la página de inicio en lugar de preservar el estado de búsqueda activo (). Esto causaba que la búsqueda se borrara del historial y el siguiente retroceso cerrara la aplicación.
+- **Acción:** Re-insertar explícitamente el estado de búsqueda  reconstruido dinámicamente con el valor del input, preservando el historial y permitiendo que el segundo retroceso regrese correctamente a la página principal.
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - CORRECCIÓN AJUSTE POST-COMMIT DE HISTORIAL (14/07/2026)**
+
+**Archivo: main.js (popstate)**
+- **Hallazgo:** Cuando el input de búsqueda está enfocado y se realiza un retroceso, el navegador ya ha retrocedido un estado en el historial (dejando activo el estado anterior, p. ej. "categorias").
+- El código anterior re-insertaba el estado actual ya modificado (state), duplicando el estado de la página de inicio en lugar de preservar el estado de búsqueda activo ({ level: "busqueda", query: currentQuery }). Esto causaba que la búsqueda se borrara del historial y el siguiente retroceso cerrara la aplicación.
+- **Acción:** Re-insertar explícitamente el estado de búsqueda { level: "busqueda", query: currentQuery } reconstruido dinámicamente con el valor del input, preservando el historial y permitiendo que el segundo retroceso regrese correctamente a la página principal.

--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -130,3 +130,16 @@
 - **Hallazgo:** Cuando el input de búsqueda está enfocado y se realiza un retroceso, el navegador ya ha retrocedido un estado en el historial (dejando activo el estado anterior, p. ej. "categorias").
 - El código anterior re-insertaba el estado actual ya modificado (state), duplicando el estado de la página de inicio en lugar de preservar el estado de búsqueda activo ({ level: "busqueda", query: currentQuery }). Esto causaba que la búsqueda se borrara del historial y el siguiente retroceso cerrara la aplicación.
 - **Acción:** Re-insertar explícitamente el estado de búsqueda { level: "busqueda", query: currentQuery } reconstruido dinámicamente con el valor del input, preservando el historial y permitiendo que el segundo retroceso regrese correctamente a la página principal.
+
+--------------------------------------------------
+**AUDITORÍA TÉCNICA - REFINAMIENTO POST-COMMIT DEL HISTORIAL DE BÚSQUEDA (14/07/2026)**
+
+**Archivos: main.js, ui.js, navigation.js**
+- **Hallazgo:** Se identificó que la barra de búsqueda en estado enfocado (teclado abierto) y desenfocado (teclado cerrado) compartían el mismo estado de historial "busqueda". Esto causaba una duplicación en la pila de historial cuando el usuario utilizaba el gesto de retroceso para desenfocar la barra de búsqueda, impidiendo regresar a la página principal en el segundo retroceso.
+- **Acción:**
+  1. Introducido el nuevo estado de historial "busqueda_focused" para representar la barra de búsqueda enfocada / teclado abierto.
+  2. Al enfocar o escribir, el estado se establece en "busqueda_focused".
+  3. Al desenfocar (blur), el estado se reemplaza silenciosamente con "busqueda" (desenfocado).
+  4. En el primer retroceso (si está enfocado), se ejecuta blur() de inmediato, se elimina la clase "search-active" sin desfase de tiempo, y se re-inserta el estado "busqueda".
+  5. En el segundo retroceso, se vuelve correctamente al estado inicial sin duplicaciones ni cierres de aplicación.
+  6. Soportados ambos escenarios (Resultados múltiples y Modal de resultado único) con perfecta correspondencia en la pila de navegación del navegador y gestos del sistema.

--- a/ChangesLogs.txt
+++ b/ChangesLogs.txt
@@ -480,3 +480,5 @@ Archivos modificados:
 
 - main.js (popstate): Añadida interceptación de retroceso con teclado activo.
 - ui.js: Propagación de 'origin' ('marca' o 'categoria') en las funciones de visualización de niveles y actualización dinámica del botón Volver.
+
+- main.js, ui.js, navigation.js: Implementación del estado de historial 'busqueda_focused' para separar búsquedas con teclado activo de búsquedas inactivas, optimizando el flujo de retroceso de 2 y 3 gestos en móviles y PWA.

--- a/ChangesLogs.txt
+++ b/ChangesLogs.txt
@@ -477,3 +477,6 @@ Archivos modificados:
   - Asegurada la prioridad de cierre de overlays antes de la reconstrucción de niveles de contenido.
 - Archivo: navigation.js
   - Ajustada la función irAPaginaPrincipal para limpiar el historial y restaurar el estado base de forma consistente.
+
+- main.js (popstate): Añadida interceptación de retroceso con teclado activo.
+- ui.js: Propagación de 'origin' ('marca' o 'categoria') en las funciones de visualización de niveles y actualización dinámica del botón Volver.

--- a/main.js
+++ b/main.js
@@ -63,9 +63,32 @@ async function initializeApp() {
     searchInput.addEventListener('focus', () => {
         if (searchBlurTimeout) clearTimeout(searchBlurTimeout);
         document.body.classList.add('search-active');
+
+        // Sincronizar historial con el estado enfocado
+        const currentQuery = searchInput.value;
+        const currentState = window.history.state || {};
+        const isSearch = currentState.level === 'busqueda' || currentState.level === 'busqueda_focused' || window.location.hash.startsWith('#search=');
+        const newUrl = window.location.pathname + window.location.search + `#search=${encodeURIComponent(currentQuery)}`;
+
+        // Actualizar el estado global con el nivel enfocado para que filtrarContenido detecte la búsqueda activa correctamente
+        window.state.setState({ navigationState: { level: "busqueda_focused", query: currentQuery } });
+
+        if (isSearch) {
+            history.replaceState({ level: "busqueda_focused", query: currentQuery }, '', newUrl);
+        } else {
+            history.pushState({ level: "busqueda_focused", query: currentQuery }, '', newUrl);
+        }
     });
 
     searchInput.addEventListener('blur', () => {
+        // Sincronizar historial con el estado desenfocado
+        const currentQuery = searchInput.value;
+        const currentState = window.history.state || {};
+        if (currentState.level === 'busqueda_focused') {
+            const newUrl = window.location.pathname + window.location.search + `#search=${encodeURIComponent(currentQuery)}`;
+            history.replaceState({ level: "busqueda", query: currentQuery }, '', newUrl);
+        }
+
         // Se utiliza un timeout para evitar el cierre inmediato al hacer clic en el botón de limpiar (X)
         searchBlurTimeout = setTimeout(() => {
             const modalDetalle = document.getElementById('modalDetalle');
@@ -143,10 +166,18 @@ async function initializeApp() {
         // el primer retroceso debe retirar el foco de la barra de búsqueda y conservar el estado de navegación.
         if (searchInput && document.activeElement === searchInput) {
             const currentQuery = searchInput.value;
-            // Retirar foco
+
+            // Cancelar cualquier timeout activo para desenfocar y ocultar el teclado
+            if (searchBlurTimeout) clearTimeout(searchBlurTimeout);
+
+            // Retirar foco inmediatamente
             searchInput.blur();
+
+            // Ocultar la barra activa e iniciar la animación inversa simultáneamente
+            document.body.classList.remove('search-active');
+
             // Evitar que el historial se desplace hacia atrás recuperando la posición actual
-            // mediante la re-inserción del estado de búsqueda activo.
+            // mediante la re-inserción del estado de búsqueda activo desenfocado.
             if (currentQuery) {
                 const newUrl = window.location.pathname + window.location.search + `#search=${encodeURIComponent(currentQuery)}`;
                 history.pushState({ level: "busqueda", query: currentQuery }, '', newUrl);
@@ -241,12 +272,20 @@ async function initializeApp() {
                 case 'versionesEquipamiento':
                     ui.mostrarVersionesEquipamiento(state.categoria, state.marca, state.modelo);
                     break;
+                case 'busqueda_focused':
                 case 'busqueda':
                     if (searchInput) {
                         searchInput.value = state.query;
                         searchInput.parentElement.classList.add('has-text');
                     }
-                    document.body.classList.add('search-active');
+                    if (state.level === 'busqueda_focused') {
+                        document.body.classList.add('search-active');
+                        // Forzar el enfoque para re-abrir el teclado virtual de inmediato
+                        setTimeout(() => searchInput.focus(), 300);
+                    } else {
+                        document.body.classList.remove('search-active');
+                        searchInput.blur();
+                    }
                     // Phase 2.4.10: Se indica que es una restauración (true) para evitar la reapertura automática de modales.
                     navigation.filtrarContenido(state.query, true);
                     break;

--- a/main.js
+++ b/main.js
@@ -142,11 +142,17 @@ async function initializeApp() {
         // Tarea 1: Si el teclado virtual está visible (el input de búsqueda tiene el foco),
         // el primer retroceso debe retirar el foco de la barra de búsqueda y conservar el estado de navegación.
         if (searchInput && document.activeElement === searchInput) {
+            const currentQuery = searchInput.value;
             // Retirar foco
             searchInput.blur();
             // Evitar que el historial se desplace hacia atrás recuperando la posición actual
-            // mediante la re-inserción del estado actual.
-            history.pushState(state, '', window.location.href);
+            // mediante la re-inserción del estado de búsqueda activo.
+            if (currentQuery) {
+                const newUrl = window.location.pathname + window.location.search + `#search=${encodeURIComponent(currentQuery)}`;
+                history.pushState({ level: "busqueda", query: currentQuery }, '', newUrl);
+            } else {
+                navigation.irAPaginaPrincipal(true);
+            }
             return;
         }
 

--- a/main.js
+++ b/main.js
@@ -139,6 +139,17 @@ async function initializeApp() {
         const state = event.state || {};
         const searchInput = document.getElementById('searchInput');
 
+        // Tarea 1: Si el teclado virtual está visible (el input de búsqueda tiene el foco),
+        // el primer retroceso debe retirar el foco de la barra de búsqueda y conservar el estado de navegación.
+        if (searchInput && document.activeElement === searchInput) {
+            // Retirar foco
+            searchInput.blur();
+            // Evitar que el historial se desplace hacia atrás recuperando la posición actual
+            // mediante la re-inserción del estado actual.
+            history.pushState(state, '', window.location.href);
+            return;
+        }
+
         // Phase 2.4.11: PRIORIDAD DE CIERRE DE COMPONENTES UI (OVERLAYS)
         // Se reordena el listener para asegurar que cualquier modal u overlay se cierre
         // antes de intentar restaurar estados de búsqueda o secciones.
@@ -192,6 +203,11 @@ async function initializeApp() {
 
         // Manejo de niveles de navegación (Cortes / Categorías)
         if (state.level) {
+            // Rehidratar origin en el estado global para conservar el contexto
+            const origin = state.origin || "categoria";
+            const currentState = window.state.getState().navigationState || {};
+            window.state.setState({ navigationState: { ...currentState, origin } });
+
             switch (state.level) {
                 case 'marcas':
                     ui.mostrarMarcas(state.categoria);

--- a/navigation.js
+++ b/navigation.js
@@ -115,18 +115,18 @@ export function filtrarContenido(textoBusqueda, isRestoring = false) {
     // Se utiliza pushState solo la primera vez que se entra en modo búsqueda para registrar el estado en el historial.
     // Las actualizaciones subsecuentes (mientras se teclea) usan replaceState para no saturar el historial.
     const currentState = getState();
-    const wasAlreadySearching = currentState.navigationState && currentState.navigationState.level === "busqueda";
+    const wasAlreadySearching = currentState.navigationState && (currentState.navigationState.level === "busqueda" || currentState.navigationState.level === "busqueda_focused");
 
     // Se guarda el término de búsqueda en el estado para permitir la navegación hacia atrás.
-    setState({ navigationState: { level: "busqueda", query: textoBusqueda } });
+    setState({ navigationState: { level: "busqueda_focused", query: textoBusqueda } });
 
     // Actualizar el hash para Deep Linking ANTES de renderizar resultados.
     const newUrl = window.location.pathname + window.location.search + `#search=${encodeURIComponent(textoBusqueda)}`;
 
     if (wasAlreadySearching) {
-        history.replaceState({ level: "busqueda", query: textoBusqueda }, '', newUrl);
+        history.replaceState({ level: "busqueda_focused", query: textoBusqueda }, '', newUrl);
     } else {
-        history.pushState({ level: "busqueda", query: textoBusqueda }, '', newUrl);
+        history.pushState({ level: "busqueda_focused", query: textoBusqueda }, '', newUrl);
     }
 
     // --- LÓGICA DE CLASIFICACIÓN MEJORADA (BASADA EN RESULTADOS) ---

--- a/ui.js
+++ b/ui.js
@@ -612,7 +612,7 @@ export function mostrarVersiones(filas, categoria, marca, modelo) {
     // Comentario: Lógica dinámica MEJORADA para el botón "Volver".
     // Determina si el paso anterior fue una búsqueda, selección de tipo de encendido o de versión de equipamiento.
     let backAction;
-    if (previousState.level === 'busqueda') {
+    if (previousState.level === 'busqueda' || previousState.level === 'busqueda_focused') {
         // Si venimos de una búsqueda, el botón debe regresar a los resultados de esa búsqueda.
         backAction = `window.ui.regresarABusqueda()`;
     } else if (previousState.level === 'tiposEncendido') {
@@ -650,7 +650,7 @@ export function regresarABusqueda() {
     // que contiene la información de la búsqueda es el 'previousState'.
     const prevState = navigationState ? navigationState.previousState : null;
 
-    if (prevState && prevState.level === 'busqueda' && prevState.query) {
+    if (prevState && (prevState.level === 'busqueda' || prevState.level === 'busqueda_focused') && prevState.query) {
         // Vuelve a ejecutar la función de filtrado con el término de búsqueda guardado en el estado anterior.
         window.navigation.filtrarContenido(prevState.query);
     } else {

--- a/ui.js
+++ b/ui.js
@@ -333,9 +333,9 @@ export function mostrarMarcas(categoria) {
     const { catalogData } = getState();
     const { cortes } = catalogData;
 
-    setState({ navigationState: { level: "marcas", categoria: categoria } });
+    setState({ navigationState: { level: "marcas", categoria: categoria, origin: "categoria" } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "marcas")) {
-        window.history.pushState({ level: "marcas", categoria: categoria }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "marcas", categoria: categoria, origin: "categoria" }, '', window.location.pathname + window.location.search);
     }
     const cont = document.getElementById("contenido");
     cont.innerHTML = `<span class="backBtn" onclick="window.navigation.irAPaginaPrincipal()">${backSvg} Volver</span><h4>Marcas de ${categoria}</h4>`;
@@ -375,9 +375,9 @@ export function mostrarModelosPorMarca(marca) {
 
     // Se establece el estado de navegación actual capturando el estado previo.
     const previousState = getState().navigationState || {};
-    setState({ navigationState: { level: "modelosPorMarca", marca: marca, previousState } });
+    setState({ navigationState: { level: "modelosPorMarca", marca: marca, origin: "marca", previousState } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "modelosPorMarca")) {
-        window.history.pushState({ level: "modelosPorMarca", marca: marca }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "modelosPorMarca", marca: marca, origin: "marca" }, '', window.location.pathname + window.location.search);
     }
     const cont = document.getElementById("contenido");
 
@@ -433,8 +433,9 @@ export function mostrarModelosPorMarca(marca) {
  * @param {string} modelo - El modelo del vehículo.
  */
 function navegarADetallesDeModelo(categoria, marca, modelo) {
-    const { catalogData } = getState();
+    const { catalogData, navigationState } = getState();
     const { cortes } = catalogData;
+    const origin = (navigationState && navigationState.origin) || "categoria";
 
     // Comentario: Lógica de navegación refactorizada para omitir pantallas de selección con una sola opción.
     // 1. Obtener todos los cortes para el modelo específico.
@@ -482,13 +483,14 @@ function navegarADetallesDeModelo(categoria, marca, modelo) {
 }
 
 export function mostrarModelos(categoria, marca, versionEquipamiento = null) {
-    const { catalogData } = getState();
+    const { catalogData, navigationState } = getState();
     const { cortes } = catalogData;
 
-    const previousState = getState().navigationState || {};
-    setState({ navigationState: { level: "modelos", categoria, marca, versionEquipamiento, previousState } });
+    const previousState = navigationState || {};
+    const origin = previousState.origin || "categoria";
+    setState({ navigationState: { level: "modelos", categoria, marca, versionEquipamiento, origin, previousState } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "modelos")) {
-        window.history.pushState({ level: "modelos", categoria, marca, versionEquipamiento }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "modelos", categoria, marca, versionEquipamiento, origin }, '', window.location.pathname + window.location.search);
     }
     const cont = document.getElementById("contenido");
 
@@ -496,7 +498,7 @@ export function mostrarModelos(categoria, marca, versionEquipamiento = null) {
     let backAction;
     if (versionEquipamiento) {
         backAction = `window.ui.mostrarVersionesEquipamiento('${categoria}', '${marca}')`;
-    } else if (previousState.level === 'modelosPorMarca') {
+    } else if (origin === 'marca' || previousState.level === 'modelosPorMarca') {
         backAction = `window.ui.mostrarModelosPorMarca('${marca}')`;
     } else {
         backAction = `window.ui.mostrarMarcas('${categoria}')`;
@@ -537,12 +539,13 @@ export function mostrarModelos(categoria, marca, versionEquipamiento = null) {
 }
 
 export function mostrarTiposEncendido(categoria, marca, versionEquipamiento, modelo) {
-     const { catalogData } = getState();
+     const { catalogData, navigationState } = getState();
     const { cortes } = catalogData;
-    const previousState = getState().navigationState || {};
-    setState({ navigationState: { level: "tiposEncendido", categoria, marca, versionEquipamiento, modelo, previousState } });
+    const previousState = navigationState || {};
+    const origin = previousState.origin || "categoria";
+    setState({ navigationState: { level: "tiposEncendido", categoria, marca, versionEquipamiento, modelo, origin, previousState } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "tiposEncendido")) {
-        window.history.pushState({ level: "tiposEncendido", categoria, marca, versionEquipamiento, modelo }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "tiposEncendido", categoria, marca, versionEquipamiento, modelo, origin }, '', window.location.pathname + window.location.search);
     }
 
     const cont = document.getElementById("contenido");
@@ -553,7 +556,7 @@ export function mostrarTiposEncendido(categoria, marca, versionEquipamiento, mod
     let backAction;
     if (previousState.level === 'versionesEquipamiento') {
         backAction = `window.ui.mostrarVersionesEquipamiento('${categoria}', '${marca}', '${modelo}')`;
-    } else if (previousState.level === 'modelosPorMarca') {
+    } else if (origin === 'marca' || previousState.level === 'modelosPorMarca') {
         backAction = `window.ui.mostrarModelosPorMarca('${marca}')`;
     } else {
         backAction = `window.ui.mostrarModelos('${categoria}', '${marca}')`;
@@ -597,10 +600,12 @@ export function mostrarTiposEncendido(categoria, marca, versionEquipamiento, mod
 }
 
 export function mostrarVersiones(filas, categoria, marca, modelo) {
-    const previousState = getState().navigationState || {};
-    setState({ navigationState: { level: "versiones", categoria, marca, modelo, previousState } });
+    const { navigationState } = getState();
+    const previousState = navigationState || {};
+    const origin = previousState.origin || "categoria";
+    setState({ navigationState: { level: "versiones", categoria, marca, modelo, origin, previousState } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "versiones")) {
-        window.history.pushState({ level: "versiones", categoria, marca, modelo }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "versiones", categoria, marca, modelo, origin }, '', window.location.pathname + window.location.search);
     }
     const cont = document.getElementById("contenido");
 
@@ -617,7 +622,7 @@ export function mostrarVersiones(filas, categoria, marca, modelo) {
         backAction = `window.ui.mostrarTiposEncendido('${categoria}', '${marca}', ${veq}, '${modelo}')`;
     } else if (previousState.level === 'versionesEquipamiento') {
         backAction = `window.ui.mostrarVersionesEquipamiento('${categoria}', '${marca}', '${modelo}')`;
-    } else if (previousState.level === 'modelosPorMarca') {
+    } else if (origin === 'marca' || previousState.level === 'modelosPorMarca') {
         // Soporte para el flujo de navegación por marca (modelosPorMarca).
         backAction = `window.ui.mostrarModelosPorMarca('${marca}')`;
     } else {
@@ -655,19 +660,20 @@ export function regresarABusqueda() {
 }
 
 export function mostrarVersionesEquipamiento(categoria, marca, modelo) {
-    const { catalogData } = getState();
+    const { catalogData, navigationState } = getState();
     const { cortes } = catalogData;
 
-    const previousState = getState().navigationState || {};
-    setState({ navigationState: { level: "versionesEquipamiento", categoria, marca, modelo, previousState } });
+    const previousState = navigationState || {};
+    const origin = previousState.origin || "categoria";
+    setState({ navigationState: { level: "versionesEquipamiento", categoria, marca, modelo, origin, previousState } });
     if (window.history && window.history.pushState && (!window.history.state || window.history.state.level !== "versionesEquipamiento")) {
-        window.history.pushState({ level: "versionesEquipamiento", categoria, marca, modelo }, '', window.location.pathname + window.location.search);
+        window.history.pushState({ level: "versionesEquipamiento", categoria, marca, modelo, origin }, '', window.location.pathname + window.location.search);
     }
     const cont = document.getElementById("contenido");
 
     // Comentario: Lógica dinámica para el botón "Volver".
     // Se añade soporte para el flujo de navegación por marca (modelosPorMarca).
-    const backAction = previousState.level === 'modelosPorMarca'
+    const backAction = origin === 'marca' || previousState.level === 'modelosPorMarca'
         ? `window.ui.mostrarModelosPorMarca('${marca}')`
         : `window.ui.mostrarModelos('${categoria}', '${marca}')`;
 


### PR DESCRIPTION
This change addresses mobile PWA navigation bugs by:
1. Retaining user on the same search page and closing the virtual keyboard on first back action/gesture if active.
2. Tracking the 'origin' state ('marca' or 'categoria') across all level-based view functions in ui.js, avoiding cross-contamination of breadcrumbs and pathways when clicking back.

---
*PR created automatically by Jules for task [10042656914810879026](https://jules.google.com/task/10042656914810879026) started by @infogpstech*