### PR TITLE
GPSpedia Frontend Refinements v2.1.5

### DIFF
--- a/Auditoria.txt
+++ b/Auditoria.txt
@@ -428,3 +428,62 @@ Estrategia de corrección:
   - Introducir `performSilentSync` en `ui.js` para reconciliar las modificaciones de cortes, marcas y agregados en segundo plano sin alterar el foco, scroll, ni modales abiertos.
   - Sincronizar reactivamente el detalle del modal mediante resolución directa y dinámica por ID.
   - Implementar pre-carga e inserción animada de nuevos recursos (imágenes, tarjetas) sin parpadeos visuales.
+
+===================================================================
+AUDITORÍA DE MEJORAS DE FRONTEND (VERSIÓN 2.1.5) (18/02/2026)
+===================================================================
+
+ID del hallazgo: H-FRONT-v2.1.5-01
+Título: Ausencia de versión de equipamiento en coincidencias del formulario de nuevos cortes
+Descripción: Durante la Etapa 1.5 en `add_cortes.html`, se listan coincidencias de vehículos similares para evitar duplicados, pero no se indica la versión de equipamiento (`match.versionesAplicables`). Adicionalmente, el sistema debe ser capaz de comparar y emparejar versiones agrupadas de forma flexible (ej. 'LX / EX / Sport' vs 'Sport, LX, EX') sin importar el orden, casing o delimitadores.
+Ubicación:
+  - Archivo: `add_cortes.html` (displayMatches)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Mostrar la versión del vehículo en la match card.
+  - Implementar un normalizador de versiones similar a `normalizeVersion` de `ui.js` para realizar una comparación de compatibilidad e indicar si coincide con la versión ingresada por el usuario.
+
+ID del hallazgo: H-FRONT-v2.1.5-02
+Título: Orden incorrecto de z-index en Lightbox de configuración de relay
+Descripción: Cuando se abre el modal secundario de configuración de relay desde el modal de detalle, abrir el Lightbox del diagrama técnico lo muestra por detrás del modal de relay debido a que el z-index de `.lightbox` (1700) es menor que el de `.info-modal` (2100).
+Ubicación:
+  - Archivo: `style.css` (.lightbox)
+Impacto: Alto
+Riesgo: Muy bajo
+Estrategia de corrección:
+  - Incrementar el z-index de `.lightbox` a 2200 para que se superponga correctamente a los modales de información y detalle.
+
+ID del hallazgo: H-FRONT-v2.1.5-03
+Título: Falta de navegación interactiva desde logotipo de marca en modal de detalle
+Descripción: El logotipo de la marca mostrado en el encabezado del modal de detalle es estático. Al hacer clic debería cerrar el modal y navegar al catálogo mostrando únicamente los modelos pertenecientes a esa marca.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Hacer clickable el logotipo de marca con un cursor `pointer`.
+  - En su evento de clic, cerrar el modal, actualizar el estado de historial a `modelosPorMarca` (vía replaceState) y ejecutar `mostrarModelosPorMarca` para la marca correspondiente.
+
+ID del hallazgo: H-FRONT-v2.1.5-04
+Título: Falta de navegación desde categoría del vehículo en modal de detalle
+Descripción: La categoría del vehículo mostrada debajo de la marca/modelo en el modal de detalle es estática. Al hacer clic debería cerrar el modal y filtrar los modelos de esa marca que correspondan a esa categoría específica.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Convertir el texto de categoría en un elemento de navegación interactivo clickable.
+  - Al hacer clic, cerrar el modal, actualizar el estado de navegación a `modelos` (vía replaceState) y ejecutar `mostrarModelos` para filtrar por marca y categoría.
+
+ID del hallazgo: H-FRONT-v2.1.5-05
+Título: Falta de navegación rápida entre generaciones en el modal de detalle
+Descripción: No existe una vía rápida para saltar entre generaciones del mismo modelo de vehículo desde el modal de detalle, lo que obliga al usuario a volver atrás y re-navegar.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Alto
+Riesgo: Medio
+Estrategia de corrección:
+  - Identificar todas las generaciones del mismo modelo del vehículo (coincidiendo en marca, modelo, categoría, tipo de encendido y versión normalizada) ordenadas de forma ascendente por año de inicio (`anoDesde`).
+  - Añadir flechas navegables `<` y `>` al lado del rango de años si existen múltiples generaciones.
+  - Implementar acciones en las flechas que llamen a `mostrarDetalleModal` para la generación anterior o siguiente, enviando un parámetro `isNavigation = true` para actualizar la vista sin agregar nuevos registros repetidos a la pila del historial.

--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -278,3 +278,62 @@ Estrategia de corrección:
   - Hacer que el botón "Es más antiguo" se muestre siempre en `showStep1` independientemente de `isOldModel`.
   - Modificar su acción para invocar `showStepInput(true)`, permitiendo al usuario ingresar el año específico para la opción "Es más antiguo".
   - Actualizar `showStepInput` para aceptar el parámetro `isFromAntiguo` y registrar la respuesta adecuada.
+
+===================================================================
+AUDITORÍA DE MEJORAS DE FRONTEND (VERSIÓN 2.1.5) (18/02/2026)
+===================================================================
+
+ID del hallazgo: H-FRONT-v2.1.5-01
+Título: Ausencia de versión de equipamiento en coincidencias del formulario de nuevos cortes
+Descripción: Durante la Etapa 1.5 en `add_cortes.html`, se listan coincidencias de vehículos similares para evitar duplicados, pero no se indica la versión de equipamiento (`match.versionesAplicables`). Adicionalmente, el sistema debe ser capaz de comparar y emparejar versiones agrupadas de forma flexible (ej. 'LX / EX / Sport' vs 'Sport, LX, EX') sin importar el orden, casing o delimitadores.
+Ubicación:
+  - Archivo: `add_cortes.html` (displayMatches)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Mostrar la versión del vehículo en la match card.
+  - Implementar un normalizador de versiones similar a `normalizeVersion` de `ui.js` para realizar una comparación de compatibilidad e indicar si coincide con la versión ingresada por el usuario.
+
+ID del hallazgo: H-FRONT-v2.1.5-02
+Título: Orden incorrecto de z-index en Lightbox de configuración de relay
+Descripción: Cuando se abre el modal secundario de configuración de relay desde el modal de detalle, abrir el Lightbox del diagrama técnico lo muestra por detrás del modal de relay debido a que el z-index de `.lightbox` (1700) es menor que el de `.info-modal` (2100).
+Ubicación:
+  - Archivo: `style.css` (.lightbox)
+Impacto: Alto
+Riesgo: Muy bajo
+Estrategia de corrección:
+  - Incrementar el z-index de `.lightbox` a 2200 para que se superponga correctamente a los modales de información y detalle.
+
+ID del hallazgo: H-FRONT-v2.1.5-03
+Título: Falta de navegación interactiva desde logotipo de marca en modal de detalle
+Descripción: El logotipo de la marca mostrado en el encabezado del modal de detalle es estático. Al hacer clic debería cerrar el modal y navegar al catálogo mostrando únicamente los modelos pertenecientes a esa marca.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Hacer clickable el logotipo de marca con un cursor `pointer`.
+  - En su evento de clic, cerrar el modal, actualizar el estado de historial a `modelosPorMarca` (vía replaceState) y ejecutar `mostrarModelosPorMarca` para la marca correspondiente.
+
+ID del hallazgo: H-FRONT-v2.1.5-04
+Título: Falta de navegación desde categoría del vehículo en modal de detalle
+Descripción: La categoría del vehículo mostrada debajo de la marca/modelo en el modal de detalle es estática. Al hacer clic debería cerrar el modal y filtrar los modelos de esa marca que correspondan a esa categoría específica.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Medio
+Riesgo: Bajo
+Estrategia de corrección:
+  - Convertir el texto de categoría en un elemento de navegación interactivo clickable.
+  - Al hacer clic, cerrar el modal, actualizar el estado de navegación a `modelos` (vía replaceState) y ejecutar `mostrarModelos` para filtrar por marca y categoría.
+
+ID del hallazgo: H-FRONT-v2.1.5-05
+Título: Falta de navegación rápida entre generaciones en el modal de detalle
+Descripción: No existe una vía rápida para saltar entre generaciones del mismo modelo de vehículo desde el modal de detalle, lo que obliga al usuario a volver atrás y re-navegar.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Alto
+Riesgo: Medio
+Estrategia de corrección:
+  - Identificar todas las generaciones del mismo modelo del vehículo (coincidiendo en marca, modelo, categoría, tipo de encendido y versión normalizada) ordenadas de forma ascendente por año de inicio (`anoDesde`).
+  - Añadir flechas navegables `<` y `>` al lado del rango de años si existen múltiples generaciones.
+  - Implementar acciones en las flechas que llamen a `mostrarDetalleModal` para la generación anterior o siguiente, enviando un parámetro `isNavigation = true` para actualizar la vista sin agregar nuevos registros repetidos a la pila del historial.

--- a/ChangesLogs.txt
+++ b/ChangesLogs.txt
@@ -212,7 +212,7 @@
 
 **Archivo: ui.js**
 - **Líneas 280-291:** Actualizada `mostrarModelosPorMarca` para capturar `previousState` y manejar dinámicamente el botón "Volver" (regreso a búsqueda o página principal).
-- **Líneas 416-424:** Actualizada `mostrarTiposEncendido` para detectar si el origen es `modelosPorMarca` y retornar correctamente a la lista global de modelos de la marca.
+- **Líneas 416-424:** Actualizada `mostrarTiposEncendido` para detectar si el origen es `modelosPorMarca` and retornar correctamente a la lista global de modelos de la marca.
 - **Líneas 481-483:** Añadido caso en `mostrarVersiones` para retornar a `mostrarModelosPorMarca` si ese era el nivel previo.
 - **Líneas 532-540:** Modificada `mostrarVersionesEquipamiento` para capturar estado previo y corregir la navegación circular hacia atrás.
 
@@ -588,3 +588,19 @@ Archivos modificados:
 - Se ajustó `mostrarDetalleModal` para que resuelva de forma dinámica y reactiva el ítem más reciente a partir del catálogo global por ID en tiempo de apertura, evitando inconsistencias debido a cierres de eventos en tarjetas existentes.
 - Se ajustó `updateOpenModalIfActive` para persistir los cambios visuales en segundo plano en el historial visto sin provocar bucles de suscripción de estado o reconstrucciones de grid en categorías que causen pérdida de la posición de scroll del usuario.
 - Se diseñó `insertNewVehicleFluently` para incorporar nuevos vehículos de manera fluida y animada en el carrusel de "Últimos Agregados" o en los sub-grids activos de catálogo de manera totalmente consistente con la interfaz.
+
+**CHANGES LOG - 18/02/2026 (REFINAMIENTOS DEL FRONTEND - VERSIÓN 2.1.5)**
+
+**Archivo: add_cortes.html**
+- Tarea 1: Agregada la versión de equipamiento en las tarjetas de coincidencias del formulario de registro en la Etapa 1.5. Implementado un algoritmo robusto de normalización de variantes agrupadas (ej. "LX, EX, Sport" vs "sport / lx / ex") que las identifica como equivalentes independientemente del orden, espacios, mayúsculas o delimitadores, mostrando una etiqueta de color verde "(Coincide)" cuando hay coincidencia exacta con el formulario.
+
+**Archivo: style.css**
+- Tarea 2: Se ajustó el z-index de la clase `.lightbox` a `2200` para garantizar que la imagen técnica ampliada del diagrama se superponga adecuadamente al modal secundario de configuración del relay (z-index: 2100) y al modal de detalle (z-index: 1600).
+
+**Archivo: ui.js**
+- Tarea 3: Modificado el logotipo de marca en el modal de detalle para actuar como enlace interactivo clickable (`cursor: pointer`). Al hacer clic, cierra el modal de detalle, cambia el estado de navegación de manera segura (con `replaceState`) y muestra todos los modelos de dicha marca.
+- Tarea 4: Convertida la categoría del vehículo en el modal de detalle en un enlace clickable con estilo subrayado. Al hacer clic, se cierra el modal y se muestra únicamente los modelos de esa categoría bajo la misma marca.
+- Tarea 5: Implementadas flechas navegables `<` y `>` para viajar de manera rápida entre las generaciones del mismo modelo de vehículo (con idénticos marca, modelo, categoría, encendido y versión de equipamiento) ordenadas cronológicamente por año. Las flechas solo aparecen si hay múltiples generaciones disponibles y respetan los límites cronológicos. El cambio de generación reutiliza de forma limpia la función `mostrarDetalleModal` enviando un flag de control para evitar la inserción de registros duplicados en el historial de navegación.
+
+**Global:**
+- Tarea 6: Se incrementó la versión global del proyecto en todos los archivos del frontend y recursos de documentación a la versión **2.1.5** (ej. index.html, ui.js, main.js, style.css, navigation.js, auth.js, state.js, etc.), manteniendo todos los microservicios e integraciones del backend intactas.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GPSpedia v2.4 - Plataforma Técnica Vehicular
+# GPSpedia v2.1.5 - Plataforma Técnica Vehicular
 
 ## 1. Descripción General
 GPSpedia es una Aplicación Web Progresiva (PWA) de alto rendimiento diseñada específicamente para técnicos e instaladores de sistemas de seguridad y rastreo vehicular. La plataforma centraliza, estandariza y facilita el acceso a información crítica sobre puntos de corte (bomba de combustible, ignición, señal a boton de encendido), diagramas de conexión y guías de desarme de paneles plasticod para una amplia variedad de marcas y modelos de vehículos.
@@ -78,4 +78,4 @@ Por motivos de seguridad operativa y saneamiento del código antes de producció
 La lógica de estos componentes se encuentra resguardada de forma privada bajo la administración del proyecto. El repositorio actual contiene la totalidad de la interfaz de usuario y la lógica de integración necesaria para que la plataforma opere contra los endpoints autorizados definidos en la configuración.
 
 ---
-*GPSpedia v2.4 - 2026 todos los derechos reservados.*
+*GPSpedia v2.1.5 - 2026 todos los derechos reservados.*

--- a/add_cortes.html
+++ b/add_cortes.html
@@ -1,4 +1,4 @@
-<!-- GPSpedia Frontend Component | Version: 2.0 -->
+<!-- GPSpedia Frontend Component | Version: 2.1.5 -->
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -262,7 +262,7 @@
     </div>
 
     <script type="module">
-        // COMPONENT VERSION: 3.0.1
+        // COMPONENT VERSION: 2.1.5
         import { routeAction } from './api-config.js';
         import './lightbox.js';
         const SESSION_KEY = 'gpsepedia_session';
@@ -272,6 +272,8 @@
             selectedVehicleId: null,
             colaborador: ''
         };
+
+        const normalizeVersion = (v) => (v || "").toString().toLowerCase().replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(Boolean).sort().join(' ');
 
         // --- INITIALIZATION ---
         document.addEventListener('DOMContentLoaded', init);
@@ -424,6 +426,8 @@
             const container = document.getElementById('matches-container');
             container.innerHTML = '<h2>Vehículos Similares Encontrados</h2><p>Hemos encontrado registros que coinciden con tu búsqueda. Selecciona una opción:</p>';
 
+            const userVersionNormalized = normalizeVersion(state.vehicleInfo.versionesAplicables);
+
             matches.forEach(match => {
                 const yearRange = (match.anoHasta && match.anoHasta != match.anoDesde) ? `${match.anoDesde} - ${match.anoHasta}` : match.anoDesde;
                 const card = document.createElement('div');
@@ -431,12 +435,16 @@
 
                 const vehicleImg = getImageUrl(match.imagenVehiculo, 400);
 
+                const matchVersionNormalized = normalizeVersion(match.versionesAplicables);
+                const matchesUserVersion = userVersionNormalized && matchVersionNormalized && (userVersionNormalized === matchVersionNormalized);
+
                 card.innerHTML = `
                     <div class="match-card-header">
                         <img src="${vehicleImg}" class="match-card-img" onerror="this.src='https://via.placeholder.com/120x90?text=Sin+Imagen'">
                         <div class="match-card-info">
                             <h4>${match.marca} ${match.modelo} (${yearRange})</h4>
                             <p><strong>Encendido:</strong> ${match.tipoEncendido}</p>
+                            <p><strong>Versión:</strong> ${match.versionesAplicables || 'No especificada'} ${matchesUserVersion ? '<span style="color: #28a745; font-weight: bold; font-size: 0.9em;">(Coincide)</span>' : ''}</p>
                             <div class="match-cuts-info">
                                 <h5>Cortes Existentes:</h5>
                                 ${formatCutInfo(match)}

--- a/api-config.js
+++ b/api-config.js
@@ -1,4 +1,4 @@
-// GPSpedia Unified API Module | Version: 2.4
+// GPSpedia Unified API Module | Version: 2.1.5
 // ============================================================================
 // ÚNICA FUENTE DE VERDAD PARA LA CONFIGURACIÓN Y LÓGICA DE LA API
 // ============================================================================

--- a/auth.js
+++ b/auth.js
@@ -1,4 +1,4 @@
-// GPSpedia Authentication Module | Version: 2.4
+// GPSpedia Authentication Module | Version: 2.1.5
 // Responsibilities:
 // - Manage the entire user authentication lifecycle (login, logout, session validation).
 // - Interact with the API module for backend communication.

--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<!-- GPSpedia Frontend Component | Version: 2.4.2 -->
+<!-- GPSpedia Frontend Component | Version: 2.1.5 -->
 <!DOCTYPE html>
 <html lang="es">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GPSpedia v2.5.7</title>
+    <title>GPSpedia v2.1.5</title>
 <link rel="icon" href="https://drive.google.com/thumbnail?id=1NxBx-W_gWmcq3fA9zog6Dpe-WXpH_2e8&sz=w256">
 <link rel="manifest" href="manifest.json">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -79,7 +79,7 @@
             <button type="submit">Acceder</button>
             <p id="login-error" style="color: red; display: none;"></p>
             <div style="text-align: center; margin-top: 20px;">
-                <small style="color: var(--text-disabled);">v2.5.7</small>
+                <small style="color: var(--text-disabled);">v2.1.5</small>
             </div>
         </form>
         <a href="#" id="forgot-password-link" style="color: var(--accent-color); text-decoration: none; margin-top: 15px; display: inline-block;">¿Olvidaste tu contraseña?</a>
@@ -140,7 +140,7 @@
 </div>
 
 <footer class="footer">
-  GPSpedia v2.5.7 © 2026 todos los derechos reservados.
+  GPSpedia v2.1.5 © 2026 todos los derechos reservados.
   <div class="footer-links">
       <a id="footer-about-link">Sobre Nosotros</a>
       <a id="footer-contact-link">Contáctanos</a>

--- a/lightbox.js
+++ b/lightbox.js
@@ -1,4 +1,4 @@
-// lightbox.js | Version: 2.2
+// lightbox.js | Version: 2.1.5
 // Responsibilities:
 // - Manage the application's lightbox for image zooming.
 // - Handle viewport meta tags to allow/restrict zoom dynamically.

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-// GPSpedia Main Orchestration Module | Version: 2.4.2
+// GPSpedia Main Orchestration Module | Version: 2.1.5
 // Responsibilities:
 // - Import all feature modules.
 // - Initialize the application and set up global event listeners.

--- a/navigation.js
+++ b/navigation.js
@@ -1,4 +1,4 @@
-// GPSpedia Navigation Module | Version: 2.2
+// GPSpedia Navigation Module | Version: 2.1.5
 // Responsibilities:
 // - Manage the application's view state and navigation flow.
 // - Handle user navigation actions (e.g., selecting a category or brand).

--- a/offline.js
+++ b/offline.js
@@ -1,4 +1,4 @@
-// GPSpedia Offline & Persistence Module | Version: 1.3
+// GPSpedia Offline & Persistence Module | Version: 2.1.5
 // Responsibilities:
 // - Manage IndexedDB for local storage of catalog, history, and thumbnails.
 // - Implement image compression and local caching.

--- a/state.js
+++ b/state.js
@@ -1,4 +1,4 @@
-// GPSpedia State Management Module | Version: 2.2
+// GPSpedia State Management Module | Version: 2.1.5
 // Responsibilities:
 // - Act as the single source of truth for all application data.
 // - Provide getter and setter functions to manage state mutations.

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* GPSpedia Styles | Version: 2.4.2 */
+/* GPSpedia Styles | Version: 2.1.5 */
 /* Estilos Globales */
 *, *::before, *::after {
     box-sizing: border-box;
@@ -1169,7 +1169,7 @@ body.search-active .container {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1700; /* Aumentado para estar sobre el modal de detalles */
+    z-index: 2200; /* Aumentado para estar sobre el modal de detalles y configuracion de relay */
     /* Transiciones */
     opacity: 0;
     visibility: hidden;

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-// GPSpedia UI Module | Version: 2.4.2
+// GPSpedia UI Module | Version: 2.1.5
 // Responsibilities:
 // - Render UI components based on state.
 // - Contain all functions that directly manipulate the DOM.
@@ -1117,7 +1117,7 @@ function createDetailParagraph(label, text) {
     return null;
 }
 
-export function mostrarDetalleModal(item) {
+export function mostrarDetalleModal(item, isNavigation = false) {
     const { catalogData } = getState();
     const activeItem = (catalogData && catalogData.cortes)
         ? catalogData.cortes.find(c => String(c.id) === String(item.id)) || item
@@ -1200,6 +1200,15 @@ export function mostrarDetalleModal(item) {
         setOptimizedImage(logoImg, logoUrl, IMG_SIZE_SMALL);
         logoImg.alt = `Logo ${activeItem.marca}`;
         logoImg.className = 'brand-logo-modal';
+        logoImg.style.cursor = 'pointer';
+        logoImg.onclick = () => {
+            document.getElementById("modalDetalle").classList.remove("visible");
+            setState({ navigationState: { level: "modelosPorMarca", marca: activeItem.marca, origin: "marca", previousState: {} } });
+            if (window.history && window.history.replaceState) {
+                window.history.replaceState({ level: "modelosPorMarca", marca: activeItem.marca, origin: "marca" }, '', window.location.pathname + window.location.search);
+            }
+            mostrarModelosPorMarca(activeItem.marca);
+        };
         // El tamaño se controla ahora desde style.css para mantener la consistencia.
         titleContainer.appendChild(logoImg);
     }
@@ -1216,10 +1225,73 @@ export function mostrarDetalleModal(item) {
     const subHeaderText = document.createElement('p');
     subHeaderText.style.cssText = "margin: 0; padding: 0; color: var(--text-medium); font-size: 1.1em;";
     const equipamiento = activeItem.versionesAplicables || activeItem.tipoEncendido || '';
-    const yearRangeText = activeItem.anoHasta ? `${activeItem.anoDesde} - ${activeItem.anoHasta}` : activeItem.anoDesde;
-    subHeaderText.innerHTML = `<strong>${equipamiento}</strong> | ${yearRangeText}`;
+
+    // Tarea 5: Identificar todas las generaciones del mismo modelo
+    const allCortes = (catalogData && catalogData.cortes) ? catalogData.cortes : [];
+
+    const normalizedItemVersion = normalizeVersion(activeItem.versionesAplicables);
+    const generations = allCortes.filter(c =>
+        String(c.marca).toLowerCase() === String(activeItem.marca).toLowerCase() &&
+        String(c.modelo).toLowerCase() === String(activeItem.modelo).toLowerCase() &&
+        String(c.categoria).toLowerCase() === String(activeItem.categoria).toLowerCase() &&
+        String(c.tipoEncendido).toLowerCase() === String(activeItem.tipoEncendido).toLowerCase() &&
+        normalizeVersion(c.versionesAplicables) === normalizedItemVersion
+    ).sort((a, b) => (parseInt(a.anoDesde) || 0) - (parseInt(b.anoDesde) || 0));
+
+    const currentIndex = generations.findIndex(g => String(g.id) === String(activeItem.id));
+
+    const yearRangeText = activeItem.anoHasta ? `${activeItem.anoDesde} – ${activeItem.anoHasta}` : activeItem.anoDesde;
+
+    const yearRangeContainer = document.createElement('span');
+    yearRangeContainer.style.cssText = "display: inline-flex; align-items: center; gap: 8px;";
+
+    if (generations.length > 1) {
+        if (currentIndex > 0) {
+            const leftArrow = document.createElement('span');
+            leftArrow.innerHTML = '&lt;';
+            leftArrow.style.cssText = "cursor: pointer; font-weight: bold; padding: 0 5px; color: var(--accent-color); user-select: none;";
+            leftArrow.onclick = () => {
+                mostrarDetalleModal(generations[currentIndex - 1], true);
+            };
+            yearRangeContainer.appendChild(leftArrow);
+        }
+
+        const yearTextSpan = document.createElement('span');
+        yearTextSpan.textContent = yearRangeText;
+        yearRangeContainer.appendChild(yearTextSpan);
+
+        if (currentIndex < generations.length - 1 && currentIndex !== -1) {
+            const rightArrow = document.createElement('span');
+            rightArrow.innerHTML = '&gt;';
+            rightArrow.style.cssText = "cursor: pointer; font-weight: bold; padding: 0 5px; color: var(--accent-color); user-select: none;";
+            rightArrow.onclick = () => {
+                mostrarDetalleModal(generations[currentIndex + 1], true);
+            };
+            yearRangeContainer.appendChild(rightArrow);
+        }
+    } else {
+        const yearTextSpan = document.createElement('span');
+        yearTextSpan.textContent = yearRangeText;
+        yearRangeContainer.appendChild(yearTextSpan);
+    }
+
+    subHeaderText.innerHTML = `<strong>${equipamiento}</strong> | `;
+    subHeaderText.appendChild(yearRangeContainer);
     if(activeItem.categoria) {
-         subHeaderText.innerHTML += `<br><span style="font-size: 0.9em; color: #777;">${activeItem.categoria}</span>`;
+         subHeaderText.appendChild(document.createElement("br"));
+         const catSpan = document.createElement("span");
+         catSpan.className = "category-nav-link";
+         catSpan.style.cssText = "font-size: 0.9em; color: #777; cursor: pointer; text-decoration: underline;";
+         catSpan.textContent = activeItem.categoria;
+         catSpan.onclick = () => {
+             document.getElementById("modalDetalle").classList.remove("visible");
+             setState({ navigationState: { level: "modelos", categoria: activeItem.categoria, marca: activeItem.marca, origin: "categoria", previousState: {} } });
+             if (window.history && window.history.replaceState) {
+                 window.history.replaceState({ level: "modelos", categoria: activeItem.categoria, marca: activeItem.marca, origin: "categoria" }, '', window.location.pathname + window.location.search);
+             }
+             mostrarModelos(activeItem.categoria, activeItem.marca);
+         };
+         subHeaderText.appendChild(catSpan);
     }
     subHeaderDiv.appendChild(subHeaderText);
     cont.appendChild(subHeaderDiv);
@@ -1289,7 +1361,7 @@ export function mostrarDetalleModal(item) {
     });
 
     document.getElementById("modalDetalle").classList.add("visible");
-    if (window.history && window.history.pushState) {
+    if (!isNavigation && window.history && window.history.pushState) {
         window.history.pushState({ modalOpen: true }, '');
     }
 }

--- a/users.html
+++ b/users.html
@@ -1,4 +1,4 @@
-<!-- GPSpedia Frontend Component | Version: 2.0 -->
+<!-- GPSpedia Frontend Component | Version: 2.1.5 -->
 <!DOCTYPE html>
 <html lang="es">
 <head>


### PR DESCRIPTION
Se han completado con éxito todas las tareas de refinamiento del frontend solicitadas para la versión 2.1.5 de GPSpedia:

1. **Mostrar versión de equipamiento en los resultados de coincidencia (Tarea 1):** Implementado en `add_cortes.html`. Incluye visualización de la versión de equipamiento y normalización avanzada para reconocer coincidencia de trim agrupado sin importar el orden, delimitadores o espacios.
2. **Corrección de capas z-index (Tarea 2):** Ajustado el z-index de `.lightbox` a 2200 para superponerse correctamente sobre el modal secundario de configuración de relay.
3. **Navegación desde logotipo de marca (Tarea 3):** Logotipo ahora interactivo, cerrando el modal de detalle y abriendo los modelos pertenecientes a la marca.
4. **Navegación desde categoría (Tarea 4):** Categoría ahora interactiva, cerrando el modal de detalle y mostrando los modelos de esa marca que pertenecen a dicha categoría.
5. **Navegación rápida entre generaciones (Tarea 5):** Se agregaron flechas navegables `<` y `>` para viajar cronológicamente entre generaciones equivalentes del mismo modelo si existen múltiples variantes registradas.
6. **Incremento de versión global a 2.1.5 (Tarea 6):** Actualizadas de forma limpia todas las referencias de versión en archivos de frontend y documentación.

Todos los cambios fueron auditados en Auditoria.txt y verificados visual e interactivamente mediante Playwright.

---
*PR created automatically by Jules for task [1269216723400423156](https://jules.google.com/task/1269216723400423156) started by @infogpstech*