### PR TITLE
Refine Vehicle Share Deep Link Precision

### DIFF
--- a/Auditoría.txt
+++ b/Auditoría.txt
@@ -395,3 +395,20 @@ Estrategia de corrección:
   - Implementar funciones de detección de instalación existente standalone (`window.matchMedia('(display-mode: standalone)').matches` y `navigator.standalone`).
   - Implementar la detección de Safari en iPhone y añadir un modal instructivo e interactivo personalizado para guiar al usuario en la instalación nativa.
   - Guardar el estado de la instalación/omisión de sesión en `sessionStorage` para cumplir con las especificaciones de no volver a mostrar el botón si ya está instalado o si se completó en la sesión actual.
+
+===================================================================
+AUDITORÍA DE DIRECCIONAMIENTO DE ENLACES DE MODELOS COMPARTIDOS (30/07/2024)
+===================================================================
+
+ID del hallazgo: H-SHARE-DEEPLINK-01
+Título: El enlace compartido de un modelo en el modal de detalle no se dirige al modelo específico, sino a la lista de generaciones del modelo
+Descripción: Al compartir la información de un modelo desde el modal de detalles, el botón de compartir genera un enlace que contiene la marca y el modelo como parámetros de búsqueda, pero no incluye el año de inicio (anoDesde) del modelo específico. Cuando se hace clic en el enlace, el sistema realiza una búsqueda de marca y modelo que devuelve múltiples generaciones de ese vehículo. Al haber más de un resultado, no se abre el modal de detalles del modelo de forma automática, sino que se muestra la tarjeta del modelo, y al hacer clic en ella, el usuario es redirigido a la lista de generaciones (años) en lugar de ver el detalle del modelo específico compartido.
+Ubicación:
+  - Archivo: `ui.js` (mostrarDetalleModal)
+Impacto: Alto (Afecta negativamente la experiencia del usuario al recibir un enlace compartido, no pudiendo visualizar directamente la información técnica del vehículo esperado).
+Riesgo de regresión: Muy bajo.
+Estrategia de corrección:
+  - Modificar el url del objeto shareData generado al hacer clic en el botón Compartir en `ui.js`.
+  - Construir un término de búsqueda concatenando `marca`, `modelo`, `versionesAplicables` (si existe), `tipoEncendido` (si existe) y `anoDesde`.
+  - Filtrar las propiedades vacías para asegurar que se cree una consulta limpia y bien estructurada.
+  - Esto restringirá con absoluta precisión los resultados de búsqueda a una sola generación y variante específica del vehículo. Al tener un único resultado exacto en `filtrarContenido`, la aplicación abrirá de forma inmediata e interactiva el modal de detalle para el modelo específico compartido originalmente.

--- a/ChangesLogs.txt
+++ b/ChangesLogs.txt
@@ -807,3 +807,9 @@ Archivos modificados:
 - **Líneas 644-659:** Agregados los manejadores de cierre de modal para `#ios-install-modal`.
 
 **Versión:** Mantenimiento y optimización de PWA v2.1.5.
+
+-------------------------------------------------------------------
+**CORRECCIÓN DE DIRECCIONAMIENTO DE ENLACES DE MODELOS COMPARTIDOS (30/07/2024)**
+
+**Archivo: ui.js**
+- **Líneas 1339-1349:** Se rediseñó la propiedad `url` en el objeto `shareData` dentro de `shareBtn.onclick` para construir dinámicamente un término de búsqueda muy preciso en el hash de Deep Linking (`#search=`). El término ahora concatena la marca, modelo, versión de equipamiento (`versionesAplicables`), tipo de encendido (`tipoEncendido`) y año de inicio (`anoDesde`), filtrando valores inexistentes o vacíos. Esto permite que el enlace de compartir filtre con total precisión la generación y variante específica del vehículo y la abra automáticamente de inmediato al cargar la URL.

--- a/Tareas.txt
+++ b/Tareas.txt
@@ -345,6 +345,14 @@ Cualquier cambio en estas zonas invalidará el commit.
       - **Implementación:** Modificado el texto del botón `#install-button` a "Instala la app" de forma estricta. Creado el modal de ayuda interactivo `#ios-install-modal` para guiar la instalación en Safari para iPhone. Desarrollada lógica robusta de detección e inicialización para ocultar el botón si ya está instalada o guardada en la sesión.
       - **Efecto:** Flujo de instalación fluido y multiplataforma 100% libre de errores.
 
+17. **TÍTULO: Corrección de redireccionamiento de enlaces de modelos compartidos (v2.1.5)**
+    - **ESTADO:** PENDIENTE DE REVISIÓN
+    - **ALCANCE:** ui.js, ChangesLogs.txt, Auditoría.txt, Tareas.txt
+    - **DESCRIPCIÓN DETALLADA:**
+      - **Objetivo:** Asegurar que compartir un vehículo desde el modal de detalles cree un enlace específico que se dirija directamente al modelo detallado en lugar de a la lista general de generaciones.
+      - **Implementación:** Se rediseñó la propiedad `url` en el objeto `shareData` en `ui.js` para construir dinámicamente un término de búsqueda concatenando `marca`, `modelo`, `versionesAplicables` (versión de equipamiento), `tipoEncendido` (tipo de encendido) y `anoDesde` (año), filtrando campos vacíos.
+      - **Efecto:** Al hacer clic en el enlace compartido, la aplicación filtra exactamente la generación y variante específica del vehículo y la abre de forma automática e inmediata en el modal de detalle, evitando mostrar una lista genérica de generaciones o tarjetas repetidas.
+
 ---
 **DERIVADO DE AUDITORÍA (ROADMAP v2.0) — NO EJECUTAR AÚN**
 ---

--- a/ui.js
+++ b/ui.js
@@ -1336,10 +1336,20 @@ export function mostrarDetalleModal(item, isNavigation = false) {
     shareBtn.className = "share-modal-btn";
     shareBtn.title = "Compartir este vehículo";
     shareBtn.onclick = () => {
+        const queryParts = [
+            activeItem.marca,
+            activeItem.modelo,
+            activeItem.versionesAplicables,
+            activeItem.tipoEncendido,
+            activeItem.anoDesde
+        ].filter(part => part && String(part).trim() !== "");
+
+        const shareQuery = queryParts.join(' ');
+
         const shareData = {
             title: `GPSpedia - ${activeItem.marca} ${activeItem.modelo}`,
             text: `Mira la información técnica del ${activeItem.marca} ${activeItem.modelo} (${activeItem.anoDesde}) en GPSpedia.`,
-            url: window.location.origin + window.location.pathname + `#search=${encodeURIComponent(activeItem.marca + ' ' + activeItem.modelo)}`
+            url: window.location.origin + window.location.pathname + `#search=${encodeURIComponent(shareQuery)}`
         };
 
         if (navigator.share) {


### PR DESCRIPTION
This PR fixes the shared link precision issue where sharing a vehicle from the detail modal would direct to a list of all generations instead of directly opening the specific shared model. It refines the deep-linking search query to dynamically include brand, model, version of equipment, ignition type, and year, filtering out empty values. This ensures that opening a shared link queries for a unique variant, auto-opening the detail modal. Fully tested and verified via Playwright, and documented in project files.

---
*PR created automatically by Jules for task [9395861047203085543](https://jules.google.com/task/9395861047203085543) started by @infogpstech*